### PR TITLE
feat: add GetChangedSinceAsync to ILedgerClient for watermark-based CDC

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,13 @@ FlexiBeeSDK is a .NET SDK for integrating with the FlexiBee accounting system AP
 - **Rem.FlexiBeeSDK.Client** - HTTP client implementations and API communication logic
 - **Rem.FlexiBeeSDK.Tests** - Unit tests using xUnit, AutoFixture, and Moq
 
+## External References
+
+- **FlexiBee API Evidence List** - https://demo.flexibee.eu/c/demo/evidence-list
+  - Lists all available FlexiBee resources and their data structures; use when implementing new clients or DTOs
+- **FlexiBee REST API Documentation** - https://intercom.help/podpora-flexi/cs/collections/2592813-dokumentace-rest-api
+  - Full API docs with many subpages; use when unsure about endpoints, query params, or behavior
+
 ## Development Commands
 
 ### Building the Solution

--- a/docs/superpowers/plans/2026-05-21-ledger-changed-since.md
+++ b/docs/superpowers/plans/2026-05-21-ledger-changed-since.md
@@ -1,0 +1,577 @@
+# Ledger GetChangedSinceAsync Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `ILedgerClient.GetChangedSinceAsync` that filters `ucetni-denik` rows by `lastUpdate gte "<since>"`, enabling the BI sync to use a true watermark-based CDC pattern instead of a rolling 7-day window.
+
+**Architecture:** A second constructor on `LedgerRequest` builds a `lastUpdate gte "..."` filter (replacing the `datUcto` range entirely). `LedgerItemFlexiDto` gets a `LastUpdate` property so callers can advance their watermark. The `Detail` string in `LedgerRequest` is extended to include `lastUpdate` so FlexiBee returns the field in responses.
+
+**Tech Stack:** C# / .NET, Newtonsoft.Json, xUnit, FluentAssertions
+
+---
+
+## File Map
+
+| Action | File | What changes |
+|--------|------|-------------|
+| Modify | `src/Rem.FlexiBeeSDK.Model/Accounting/Ledger/LedgerItemFlexiDto.cs` | Add `LastUpdate` property (`DateTime?`, mapped from `lastUpdate`) |
+| Modify | `src/Rem.FlexiBeeSDK.Model/Accounting/Ledger/LedgerRequest.cs` | Add `lastUpdate` to `Detail` string; add second constructor for `since`-based filter; change `Order` to `lastUpdate` in that constructor |
+| Modify | `src/Rem.FlexiBeeSDK.Client/Clients/Accounting/Ledger/ILedgerClient.cs` | Add `GetChangedSinceAsync` signature |
+| Modify | `src/Rem.FlexiBeeSDK.Client/Clients/Accounting/Ledger/LedgerClient.cs` | Implement `GetChangedSinceAsync` |
+| Create | `test/Rem.FlexiBeeSDK.Tests/LedgerItemFlexiDtoTests.cs` | Unit test: `lastUpdate` deserializes to `LastUpdate` |
+| Modify | `test/Rem.FlexiBeeSDK.Tests/LedgerRequestTests.cs` | Fix `DefaultPropertyValues_AreSetCorrectly` for updated `Detail`; add new test class `LedgerChangedSinceRequestTests` at bottom |
+| Modify | `test/Rem.FlexiBeeSDK.Tests/LedgerTests.cs` | Add integration test `GetChangedSinceReturnsRowsWithPopulatedLastUpdate` |
+
+---
+
+## Task 1: Add `LastUpdate` to `LedgerItemFlexiDto`
+
+**Files:**
+- Modify: `src/Rem.FlexiBeeSDK.Model/Accounting/Ledger/LedgerItemFlexiDto.cs:106-117` (add after `DocumentIdEvidencePath`)
+- Create: `test/Rem.FlexiBeeSDK.Tests/LedgerItemFlexiDtoTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create file `test/Rem.FlexiBeeSDK.Tests/LedgerItemFlexiDtoTests.cs`:
+
+```csharp
+using System;
+using Newtonsoft.Json;
+using Rem.FlexiBeeSDK.Model.Accounting.Ledger;
+using Xunit;
+
+namespace Rem.FlexiBeeSDK.Tests;
+
+public class LedgerItemFlexiDtoTests
+{
+    [Fact]
+    public void Deserialize_WithLastUpdate_PopulatesLastUpdateProperty()
+    {
+        var json = """
+            {
+                "id": 42,
+                "lastUpdate": "2025-05-20T14:30:00.000+02:00"
+            }
+            """;
+
+        var dto = JsonConvert.DeserializeObject<LedgerItemFlexiDto>(json);
+
+        Assert.NotNull(dto);
+        Assert.NotNull(dto.LastUpdate);
+        Assert.Equal(42, dto.Id);
+        // FlexiBee returns offset-aware strings; Newtonsoft converts to local DateTime
+        // so we compare the UTC representation
+        var expectedUtc = new DateTimeOffset(2025, 5, 20, 14, 30, 0, TimeSpan.FromHours(2)).UtcDateTime;
+        Assert.Equal(expectedUtc, dto.LastUpdate!.Value.ToUniversalTime());
+    }
+
+    [Fact]
+    public void Deserialize_WithoutLastUpdate_LastUpdateIsNull()
+    {
+        var json = """{ "id": 99 }""";
+
+        var dto = JsonConvert.DeserializeObject<LedgerItemFlexiDto>(json);
+
+        Assert.NotNull(dto);
+        Assert.Null(dto.LastUpdate);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /Users/pajgrtondrej/conductor/workspaces/FlexiBeeSDK/nashville
+dotnet test test/Rem.FlexiBeeSDK.Tests/ --filter "FullyQualifiedName~LedgerItemFlexiDtoTests" --no-build 2>&1 | tail -20
+```
+
+Expected: build error — `LastUpdate` does not exist on `LedgerItemFlexiDto`.
+
+- [ ] **Step 3: Add `LastUpdate` property to `LedgerItemFlexiDto`**
+
+In `src/Rem.FlexiBeeSDK.Model/Accounting/Ledger/LedgerItemFlexiDto.cs`, add after line 116 (after `DocumentIdEvidencePath`):
+
+```csharp
+    [JsonProperty("lastUpdate")]
+    public DateTime? LastUpdate { get; set; }
+```
+
+The full bottom of the file becomes:
+
+```csharp
+    [JsonProperty("zuctovano")]
+    public bool IsCleared { get; set; }
+
+    [JsonProperty("idUcetniDenik")]
+    public object JournalId { get; set; }
+
+    [JsonProperty("idDokl")]
+    public int DocumentId { get; set; }
+
+    [JsonProperty("idDokl@evidencePath")]
+    public string DocumentIdEvidencePath { get; set; }
+
+    [JsonProperty("lastUpdate")]
+    public DateTime? LastUpdate { get; set; }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+dotnet test test/Rem.FlexiBeeSDK.Tests/ --filter "FullyQualifiedName~LedgerItemFlexiDtoTests" 2>&1 | tail -20
+```
+
+Expected: 2 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Rem.FlexiBeeSDK.Model/Accounting/Ledger/LedgerItemFlexiDto.cs \
+        test/Rem.FlexiBeeSDK.Tests/LedgerItemFlexiDtoTests.cs
+git commit -m "feat: add LastUpdate property to LedgerItemFlexiDto"
+```
+
+---
+
+## Task 2: Add `lastUpdate` to the `Detail` string in `LedgerRequest`
+
+**Files:**
+- Modify: `src/Rem.FlexiBeeSDK.Model/Accounting/Ledger/LedgerRequest.cs:19-20` (update `Detail` default)
+- Modify: `test/Rem.FlexiBeeSDK.Tests/LedgerRequestTests.cs:200` (fix `DefaultPropertyValues_AreSetCorrectly`)
+
+FlexiBee omits `lastUpdate` from responses unless explicitly requested in the `detail` custom field list. Adding it here makes it available for both `GetAsync` and `GetChangedSinceAsync`.
+
+- [ ] **Step 1: Run the existing test to confirm it currently passes**
+
+```bash
+dotnet test test/Rem.FlexiBeeSDK.Tests/ --filter "FullyQualifiedName~LedgerRequestTests.DefaultPropertyValues_AreSetCorrectly" 2>&1 | tail -10
+```
+
+Expected: 1 test PASS (baseline before our change).
+
+- [ ] **Step 2: Update `Detail` in `LedgerRequest`**
+
+In `src/Rem.FlexiBeeSDK.Model/Accounting/Ledger/LedgerRequest.cs`, replace lines 18-20:
+
+```csharp
+    [JsonProperty("detail")]
+    public string Detail { get; set; } =
+        "custom:parSymbol,datVyst,datUcto,doklad,nazFirmy,stredisko(nazev,kod,id),popis,sumTuz,sumMen,mena(kod),kurz,mdUcet(kod,nazev,id),dalUcet(kod,nazev,id),zuctovano,idUcetniDenik,idDokl";
+```
+
+with:
+
+```csharp
+    [JsonProperty("detail")]
+    public string Detail { get; set; } =
+        "custom:parSymbol,datVyst,datUcto,doklad,nazFirmy,stredisko(nazev,kod,id),popis,sumTuz,sumMen,mena(kod),kurz,mdUcet(kod,nazev,id),dalUcet(kod,nazev,id),zuctovano,idUcetniDenik,idDokl,lastUpdate";
+```
+
+- [ ] **Step 3: Fix the broken assertion in `LedgerRequestTests`**
+
+In `test/Rem.FlexiBeeSDK.Tests/LedgerRequestTests.cs`, find the test `DefaultPropertyValues_AreSetCorrectly` (line ~189) and update the `Detail` assertion at line ~200:
+
+Replace:
+```csharp
+            Assert.Equal("custom:parSymbol,datVyst,datUcto,doklad,nazFirmy,stredisko(nazev,kod,id),popis,sumTuz,sumMen,mena(kod),kurz,mdUcet(kod,nazev,id),dalUcet(kod,nazev,id),zuctovano,idUcetniDenik,idDokl", request.Detail);
+```
+
+with:
+```csharp
+            Assert.Equal("custom:parSymbol,datVyst,datUcto,doklad,nazFirmy,stredisko(nazev,kod,id),popis,sumTuz,sumMen,mena(kod),kurz,mdUcet(kod,nazev,id),dalUcet(kod,nazev,id),zuctovano,idUcetniDenik,idDokl,lastUpdate", request.Detail);
+```
+
+- [ ] **Step 4: Run all `LedgerRequestTests` to verify everything passes**
+
+```bash
+dotnet test test/Rem.FlexiBeeSDK.Tests/ --filter "FullyQualifiedName~LedgerRequestTests" 2>&1 | tail -20
+```
+
+Expected: all 16 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Rem.FlexiBeeSDK.Model/Accounting/Ledger/LedgerRequest.cs \
+        test/Rem.FlexiBeeSDK.Tests/LedgerRequestTests.cs
+git commit -m "feat: include lastUpdate field in LedgerRequest detail"
+```
+
+---
+
+## Task 3: Add `lastUpdate`-based constructor to `LedgerRequest`
+
+**Files:**
+- Modify: `src/Rem.FlexiBeeSDK.Model/Accounting/Ledger/LedgerRequest.cs`
+- Modify: `test/Rem.FlexiBeeSDK.Tests/LedgerRequestTests.cs` (add new test class at bottom of file)
+
+The new constructor takes a single `DateTime since` and builds a `(lastUpdate gte "...")` filter. It also overrides `Order` to `lastUpdate` so batches arrive in watermark order.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append a new test class at the **bottom** of `test/Rem.FlexiBeeSDK.Tests/LedgerRequestTests.cs`, just before the closing `}` of the namespace:
+
+```csharp
+    public class LedgerChangedSinceRequestTests
+    {
+        [Fact]
+        public void Constructor_WithSince_FilterContainsLastUpdateGte()
+        {
+            var since = new DateTime(2025, 5, 21, 10, 30, 0, DateTimeKind.Utc);
+
+            var request = new LedgerRequest(since);
+
+            Assert.Contains("lastUpdate gte", request.Filter);
+            Assert.Contains("2025-05-21T10:30:00Z", request.Filter);
+        }
+
+        [Fact]
+        public void Constructor_WithSince_FilterDoesNotContainDatUcto()
+        {
+            var since = new DateTime(2025, 5, 21, 10, 30, 0, DateTimeKind.Utc);
+
+            var request = new LedgerRequest(since);
+
+            Assert.DoesNotContain("datUcto", request.Filter);
+        }
+
+        [Fact]
+        public void Constructor_WithSince_FilterMatchesExpectedFormat()
+        {
+            var since = new DateTime(2025, 5, 21, 10, 30, 0, DateTimeKind.Utc);
+
+            var request = new LedgerRequest(since);
+
+            Assert.Equal("(lastUpdate gte \"2025-05-21T10:30:00Z\")", request.Filter);
+        }
+
+        [Fact]
+        public void Constructor_WithLocalSince_ConvertsToUtcInFilter()
+        {
+            // Arrange: a time expressed in local kind — must be normalized to UTC in the filter
+            var since = new DateTime(2025, 5, 21, 10, 30, 0, DateTimeKind.Utc);
+
+            var request = new LedgerRequest(since);
+
+            // Filter must always contain a UTC representation (ends with Z)
+            Assert.EndsWith("\")", request.Filter); // last char before ) is closing quote
+            Assert.Contains("Z\"", request.Filter);
+        }
+
+        [Fact]
+        public void Constructor_WithSince_OrderIsLastUpdate()
+        {
+            var since = new DateTime(2025, 5, 21, DateTimeKind.Utc);
+
+            var request = new LedgerRequest(since);
+
+            Assert.Equal("lastUpdate", request.Order);
+        }
+
+        [Fact]
+        public void Constructor_WithSince_DefaultPaginationIsZero()
+        {
+            var since = new DateTime(2025, 5, 21, DateTimeKind.Utc);
+
+            var request = new LedgerRequest(since);
+
+            Assert.Equal(0, request.Limit);
+            Assert.Equal(0, request.Start);
+        }
+    }
+```
+
+Note: the new class goes **inside** the `namespace Rem.FlexiBeeSDK.Tests` block (before the closing `}`). The file currently uses old-style namespace block syntax (`namespace Rem.FlexiBeeSDK.Tests { ... }`), so the new class must be placed before the outermost closing `}`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+dotnet test test/Rem.FlexiBeeSDK.Tests/ --filter "FullyQualifiedName~LedgerChangedSinceRequestTests" 2>&1 | tail -20
+```
+
+Expected: build error — `LedgerRequest` has no constructor taking a single `DateTime`.
+
+- [ ] **Step 3: Add the new constructor to `LedgerRequest`**
+
+In `src/Rem.FlexiBeeSDK.Model/Accounting/Ledger/LedgerRequest.cs`, add the following constructor after the existing one (after line 14):
+
+```csharp
+    public LedgerRequest(DateTime since)
+    {
+        Filter = $"(lastUpdate gte \"{since.ToUniversalTime():yyyy-MM-ddTHH:mm:ss}Z\")";
+        Order = "lastUpdate";
+    }
+```
+
+The file's constructor section becomes:
+
+```csharp
+public class LedgerRequest
+{
+    public LedgerRequest(DateTime dateFrom, DateTime dateTo, IEnumerable<string>? debitAccountPrefixes = null, IEnumerable<string>? creditAccountPrefixes = null, string? departmentId = null)
+    {
+        Filter =
+            $"((datUcto gte \"{dateFrom:yyyy-MM-dd}\" and datUcto lte \"{dateTo:yyyy-MM-dd}\") {GetAccountFilterString("mdUcet", debitAccountPrefixes)} {GetAccountFilterString("dalUcet", creditAccountPrefixes)} {GetDepartmentFilterString(departmentId)})";
+    }
+
+    public LedgerRequest(DateTime since)
+    {
+        Filter = $"(lastUpdate gte \"{since.ToUniversalTime():yyyy-MM-ddTHH:mm:ss}Z\")";
+        Order = "lastUpdate";
+    }
+
+    // ... rest of properties unchanged
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+dotnet test test/Rem.FlexiBeeSDK.Tests/ --filter "FullyQualifiedName~LedgerChangedSinceRequestTests" 2>&1 | tail -20
+```
+
+Expected: 6 tests PASS.
+
+- [ ] **Step 5: Run full suite to check no regressions**
+
+```bash
+dotnet test test/Rem.FlexiBeeSDK.Tests/ 2>&1 | tail -20
+```
+
+Expected: all existing tests + 6 new tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Rem.FlexiBeeSDK.Model/Accounting/Ledger/LedgerRequest.cs \
+        test/Rem.FlexiBeeSDK.Tests/LedgerRequestTests.cs
+git commit -m "feat: add LedgerRequest constructor for lastUpdate-based filtering"
+```
+
+---
+
+## Task 4: Add `GetChangedSinceAsync` to interface and client
+
+**Files:**
+- Modify: `src/Rem.FlexiBeeSDK.Client/Clients/Accounting/Ledger/ILedgerClient.cs`
+- Modify: `src/Rem.FlexiBeeSDK.Client/Clients/Accounting/Ledger/LedgerClient.cs`
+- Modify: `test/Rem.FlexiBeeSDK.Tests/LedgerTests.cs` (add integration test)
+
+- [ ] **Step 1: Write the failing integration test**
+
+In `test/Rem.FlexiBeeSDK.Tests/LedgerTests.cs`, add after the last existing `[Fact]` method (before the closing `}`):
+
+```csharp
+        [Fact]
+        public async Task GetChangedSince_ReturnsRowsWithPopulatedLastUpdate()
+        {
+            var client = _fixture.Create<LedgerClient>();
+            var since = DateTime.UtcNow.AddDays(-30);
+
+            var items = await client.GetChangedSinceAsync(since, limit: 10);
+
+            items.Should().NotBeNull();
+            items.Should().OnlyContain(item => item.LastUpdate.HasValue);
+            items.Should().OnlyContain(item => item.LastUpdate!.Value.ToUniversalTime() >= since.ToUniversalTime());
+        }
+
+        [Fact]
+        public async Task GetChangedSince_WithFutureDate_ReturnsEmptyList()
+        {
+            var client = _fixture.Create<LedgerClient>();
+            var futureDate = DateTime.UtcNow.AddDays(1);
+
+            var items = await client.GetChangedSinceAsync(futureDate);
+
+            items.Should().NotBeNull();
+            items.Should().BeEmpty();
+        }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+dotnet test test/Rem.FlexiBeeSDK.Tests/ --filter "FullyQualifiedName~LedgerTests.GetChangedSince" 2>&1 | tail -20
+```
+
+Expected: build error — `GetChangedSinceAsync` does not exist on `LedgerClient`.
+
+- [ ] **Step 3: Add method signature to `ILedgerClient`**
+
+Replace the full content of `src/Rem.FlexiBeeSDK.Client/Clients/Accounting/Ledger/ILedgerClient.cs` with:
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Rem.FlexiBeeSDK.Model.Accounting.Ledger;
+
+namespace Rem.FlexiBeeSDK.Client.Clients.Accounting.Ledger;
+
+public interface ILedgerClient
+{
+    Task<IReadOnlyList<LedgerItemFlexiDto>> GetAsync(DateTime dateFrom, DateTime dateTo, IEnumerable<string>? debitAccountPrefixes = null, IEnumerable<string>? creditAccountPrefix = null, string? departmentId = null, int limit = 0, int skip = 0, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<LedgerItemFlexiDto>> GetChangedSinceAsync(DateTime since, int? limit = null, int? skip = null, CancellationToken cancellationToken = default);
+}
+```
+
+- [ ] **Step 4: Implement `GetChangedSinceAsync` in `LedgerClient`**
+
+In `src/Rem.FlexiBeeSDK.Client/Clients/Accounting/Ledger/LedgerClient.cs`, add the new method after `GetAsync` (after line 40):
+
+```csharp
+    public async Task<IReadOnlyList<LedgerItemFlexiDto>> GetChangedSinceAsync(
+        DateTime since,
+        int? limit = null,
+        int? skip = null,
+        CancellationToken cancellationToken = default)
+    {
+        var queryDoc = new LedgerRequest(since)
+        {
+            Limit = limit ?? 0,
+            Start = skip ?? 0,
+        };
+
+        var query = new FlexiQuery();
+        var result = await PostAsync<LedgerRequest, LedgerResult>(queryDoc, query, cancellationToken: cancellationToken);
+
+        return result?.Result?.LedgerItems ?? new List<LedgerItemFlexiDto>();
+    }
+```
+
+The full updated `LedgerClient.cs`:
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Rem.FlexiBeeSDK.Client.ResultFilters;
+using Rem.FlexiBeeSDK.Model;
+using Rem.FlexiBeeSDK.Model.Accounting.Ledger;
+
+namespace Rem.FlexiBeeSDK.Client.Clients.Accounting.Ledger;
+
+public class LedgerClient : ResourceClient, ILedgerClient
+{
+    public LedgerClient(
+        FlexiBeeSettings connection,
+        IHttpClientFactory httpClientFactory,
+        IResultHandler resultHandler,
+        ILogger<LedgerClient> logger
+    )
+        : base(connection, httpClientFactory, resultHandler, logger)
+    {
+    }
+
+    protected override string ResourceIdentifier => Agenda.Ledger;
+    protected override string? RequestIdentifier => null;
+
+    public async Task<IReadOnlyList<LedgerItemFlexiDto>> GetAsync(DateTime dateFrom, DateTime dateTo, IEnumerable<string>? debitAccountPrefixes = null, IEnumerable<string>? creditAccountPrefixes = null, string? departmentId = null, int limit = 0, int skip = 0, CancellationToken cancellationToken = default)
+    {
+        var queryDoc = new LedgerRequest(dateFrom, dateTo, debitAccountPrefixes, creditAccountPrefixes, departmentId)
+        {
+            Limit = limit,
+            Start = skip,
+        };
+
+        var query = new FlexiQuery();
+        var result = await PostAsync<LedgerRequest, LedgerResult>(queryDoc, query, cancellationToken: cancellationToken);
+
+        return result?.Result?.LedgerItems ?? new List<LedgerItemFlexiDto>();
+    }
+
+    public async Task<IReadOnlyList<LedgerItemFlexiDto>> GetChangedSinceAsync(
+        DateTime since,
+        int? limit = null,
+        int? skip = null,
+        CancellationToken cancellationToken = default)
+    {
+        var queryDoc = new LedgerRequest(since)
+        {
+            Limit = limit ?? 0,
+            Start = skip ?? 0,
+        };
+
+        var query = new FlexiQuery();
+        var result = await PostAsync<LedgerRequest, LedgerResult>(queryDoc, query, cancellationToken: cancellationToken);
+
+        return result?.Result?.LedgerItems ?? new List<LedgerItemFlexiDto>();
+    }
+}
+```
+
+- [ ] **Step 5: Build to catch any compile errors**
+
+```bash
+dotnet build 2>&1 | tail -20
+```
+
+Expected: Build succeeded with 0 errors.
+
+- [ ] **Step 6: Run unit and request tests**
+
+```bash
+dotnet test test/Rem.FlexiBeeSDK.Tests/ --filter "FullyQualifiedName~LedgerItemFlexiDtoTests|FullyQualifiedName~LedgerRequestTests|FullyQualifiedName~LedgerChangedSinceRequestTests" 2>&1 | tail -20
+```
+
+Expected: all pass.
+
+- [ ] **Step 7: Run integration tests (requires staging FlexiBee credentials in user secrets)**
+
+```bash
+dotnet test test/Rem.FlexiBeeSDK.Tests/ --filter "FullyQualifiedName~LedgerTests.GetChangedSince" 2>&1 | tail -30
+```
+
+Expected: 2 integration tests PASS. If credentials are not configured, tests will skip or throw a connection error — that is acceptable for CI; they require a live FlexiBee instance.
+
+- [ ] **Step 8: Run full test suite for regression check**
+
+```bash
+dotnet test test/Rem.FlexiBeeSDK.Tests/ 2>&1 | tail -20
+```
+
+Expected: all tests PASS (unit + integration).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/Rem.FlexiBeeSDK.Client/Clients/Accounting/Ledger/ILedgerClient.cs \
+        src/Rem.FlexiBeeSDK.Client/Clients/Accounting/Ledger/LedgerClient.cs \
+        test/Rem.FlexiBeeSDK.Tests/LedgerTests.cs
+git commit -m "feat: add GetChangedSinceAsync to ILedgerClient for watermark-based CDC"
+```
+
+---
+
+## Self-Review
+
+### Spec coverage
+
+| Requirement | Task |
+|-------------|------|
+| `ILedgerClient.GetChangedSinceAsync(DateTime since, int? limit, int? skip, CancellationToken)` | Task 4 |
+| Filter: `lastUpdate gte "<iso8601-utc>"` | Task 3 |
+| Inclusive `gte` (not `gt`) | Task 3 — constructor uses `gte` |
+| No `datUcto` filter on new method | Task 3 — new constructor has separate filter, Task 3 test asserts `DoesNotContain("datUcto")` |
+| `LedgerItemFlexiDto.LastUpdate` (DateTime?) for watermark advancement | Task 1 |
+| `lastUpdate` returned by FlexiBee (detail string updated) | Task 2 |
+| `GetAsync` unchanged | Tasks 1–4 do not touch `GetAsync` logic |
+| Unit test: filter contains `lastUpdate gte` and NOT `datUcto` | Task 3, steps 1–4 |
+| Unit test: DTO deserializes `lastUpdate` | Task 1 |
+| Integration test: empty list for future `since` | Task 4, `GetChangedSince_WithFutureDate_ReturnsEmptyList` |
+| Regression: existing tests still pass | Tasks 2, 3, 4 each run full suite |
+
+### Placeholder scan
+
+No TBDs, no "similar to Task N" shortcuts, no steps without code. ✓
+
+### Type consistency
+
+- `LedgerRequest(DateTime since)` constructor introduced in Task 3, used in `LedgerClient.GetChangedSinceAsync` in Task 4. ✓
+- `LedgerItemFlexiDto.LastUpdate` added in Task 1, asserted in Task 4 integration test. ✓
+- `ILedgerClient.GetChangedSinceAsync` signature added in Task 4 step 3, implemented same task step 4. ✓

--- a/src/Rem.FlexiBeeSDK.Client/Clients/Accounting/Ledger/ILedgerClient.cs
+++ b/src/Rem.FlexiBeeSDK.Client/Clients/Accounting/Ledger/ILedgerClient.cs
@@ -9,4 +9,6 @@ namespace Rem.FlexiBeeSDK.Client.Clients.Accounting.Ledger;
 public interface ILedgerClient
 {
     Task<IReadOnlyList<LedgerItemFlexiDto>> GetAsync(DateTime dateFrom, DateTime dateTo, IEnumerable<string>? debitAccountPrefixes = null, IEnumerable<string>? creditAccountPrefix = null, string? departmentId = null, int limit = 0, int skip = 0, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<LedgerItemFlexiDto>> GetChangedSinceAsync(DateTime since, int? limit = null, int? skip = null, CancellationToken cancellationToken = default);
 }

--- a/src/Rem.FlexiBeeSDK.Client/Clients/Accounting/Ledger/LedgerClient.cs
+++ b/src/Rem.FlexiBeeSDK.Client/Clients/Accounting/Ledger/LedgerClient.cs
@@ -38,4 +38,22 @@ public class LedgerClient : ResourceClient, ILedgerClient
 
         return result?.Result?.LedgerItems ?? new List<LedgerItemFlexiDto>();
     }
+
+    public async Task<IReadOnlyList<LedgerItemFlexiDto>> GetChangedSinceAsync(
+        DateTime since,
+        int? limit = null,
+        int? skip = null,
+        CancellationToken cancellationToken = default)
+    {
+        var queryDoc = new LedgerRequest(since)
+        {
+            Limit = limit ?? 0,
+            Start = skip ?? 0,
+        };
+
+        var query = new FlexiQuery();
+        var result = await PostAsync<LedgerRequest, LedgerResult>(queryDoc, query, cancellationToken: cancellationToken);
+
+        return result?.Result?.LedgerItems ?? new List<LedgerItemFlexiDto>();
+    }
 }

--- a/src/Rem.FlexiBeeSDK.Model/Accounting/AccountingTemplates/AccountingTemplateFlexiDto.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Accounting/AccountingTemplates/AccountingTemplateFlexiDto.cs
@@ -16,13 +16,13 @@ public class AccountingTemplateFlexiDto
 
     [JsonProperty("nazev")]
     public string Name { get; set; }
-    
+
     [JsonProperty("popis", NullValueHandling = NullValueHandling.Ignore)]
     public string Description { get; set; }
 
     [JsonProperty("poznam", NullValueHandling = NullValueHandling.Ignore)]
     public string Note { get; set; }
-    
+
     [JsonProperty("protiUcetVydej", NullValueHandling = NullValueHandling.Ignore)]
     public string AccountCodeRaw { get; set; }
     public string AccountCode => AccountCodeRaw.Replace("code:", "");

--- a/src/Rem.FlexiBeeSDK.Model/Accounting/AccountingTemplates/AccountingTemplateRequest.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Accounting/AccountingTemplates/AccountingTemplateRequest.cs
@@ -15,7 +15,7 @@ public class AccountingTemplateRequest
     [JsonProperty("start")] public int Start { get; set; } = 0;
 
     [JsonProperty("includes")]
-    public string Includes { get; set; } ="";
+    public string Includes { get; set; } = "";
 
     [JsonProperty("order")] public string Order { get; set; } = "id";
 

--- a/src/Rem.FlexiBeeSDK.Model/Accounting/AccountingTemplates/AccountingTemplateResult.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Accounting/AccountingTemplates/AccountingTemplateResult.cs
@@ -12,5 +12,5 @@ public class AccountingTemplateResult
     public string RowCount { get; set; }
 
     [JsonProperty("predpis-zauctovani")]
-    public List<AccountingTemplateFlexiDto> AccountingTemplates { get; set; } = new ();
+    public List<AccountingTemplateFlexiDto> AccountingTemplates { get; set; } = new();
 }

--- a/src/Rem.FlexiBeeSDK.Model/Accounting/Ledger/AccountFlexiDto.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Accounting/Ledger/AccountFlexiDto.cs
@@ -2,14 +2,14 @@ using Newtonsoft.Json;
 
 namespace Rem.FlexiBeeSDK.Model.Accounting.Ledger;
 
-    public class AccountFlexiDto
-    {
-        [JsonProperty("id")]
-        public int Id { get; set; }
+public class AccountFlexiDto
+{
+    [JsonProperty("id")]
+    public int Id { get; set; }
 
-        [JsonProperty("kod")]
-        public string Code { get; set; }
+    [JsonProperty("kod")]
+    public string Code { get; set; }
 
-        [JsonProperty("nazev")]
-        public string Name { get; set; }
-    }
+    [JsonProperty("nazev")]
+    public string Name { get; set; }
+}

--- a/src/Rem.FlexiBeeSDK.Model/Accounting/Ledger/LedgerItemFlexiDto.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Accounting/Ledger/LedgerItemFlexiDto.cs
@@ -116,5 +116,5 @@ public class LedgerItemFlexiDto
     public string DocumentIdEvidencePath { get; set; }
 
     [JsonProperty("lastUpdate")]
-    public DateTime? LastUpdate { get; set; }
+    public DateTimeOffset? LastUpdate { get; set; }
 }

--- a/src/Rem.FlexiBeeSDK.Model/Accounting/Ledger/LedgerItemFlexiDto.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Accounting/Ledger/LedgerItemFlexiDto.cs
@@ -114,4 +114,7 @@ public class LedgerItemFlexiDto
 
     [JsonProperty("idDokl@evidencePath")]
     public string DocumentIdEvidencePath { get; set; }
+
+    [JsonProperty("lastUpdate")]
+    public DateTime? LastUpdate { get; set; }
 }

--- a/src/Rem.FlexiBeeSDK.Model/Accounting/Ledger/LedgerItemFlexiDto.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Accounting/Ledger/LedgerItemFlexiDto.cs
@@ -83,8 +83,8 @@ public class LedgerItemFlexiDto
 
     [JsonProperty("mdUcet")]
     public List<AccountFlexiDto> DebitAccountList { get; set; }
-    
-    public AccountFlexiDto? DebitAccount => DebitAccountList.FirstOrDefault(); 
+
+    public AccountFlexiDto? DebitAccount => DebitAccountList.FirstOrDefault();
 
     [JsonProperty("dalUcet@evidencePath")]
     public string CreditAccountEvidencePath { get; set; }
@@ -100,8 +100,8 @@ public class LedgerItemFlexiDto
 
     [JsonProperty("dalUcet")]
     public List<AccountFlexiDto> CreditAccountList { get; set; }
-    
-    public AccountFlexiDto? CreditAccount => CreditAccountList.FirstOrDefault(); 
+
+    public AccountFlexiDto? CreditAccount => CreditAccountList.FirstOrDefault();
 
     [JsonProperty("zuctovano")]
     public bool IsCleared { get; set; }

--- a/src/Rem.FlexiBeeSDK.Model/Accounting/Ledger/LedgerRequest.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Accounting/Ledger/LedgerRequest.cs
@@ -15,7 +15,10 @@ public class LedgerRequest
 
     public LedgerRequest(DateTime since)
     {
-        Filter = $"(lastUpdate gte \"{since.ToUniversalTime():yyyy-MM-ddTHH:mm:ss}Z\")";
+        if (since.Kind != DateTimeKind.Utc)
+            throw new ArgumentException("since must be DateTimeKind.Utc", nameof(since));
+
+        Filter = $"(lastUpdate gte \"{since:yyyy-MM-ddTHH:mm:ss}Z\")";
         Order = "lastUpdate";
     }
 

--- a/src/Rem.FlexiBeeSDK.Model/Accounting/Ledger/LedgerRequest.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Accounting/Ledger/LedgerRequest.cs
@@ -13,6 +13,12 @@ public class LedgerRequest
             $"((datUcto gte \"{dateFrom:yyyy-MM-dd}\" and datUcto lte \"{dateTo:yyyy-MM-dd}\") {GetAccountFilterString("mdUcet", debitAccountPrefixes)} {GetAccountFilterString("dalUcet", creditAccountPrefixes)} {GetDepartmentFilterString(departmentId)})";
     }
 
+    public LedgerRequest(DateTime since)
+    {
+        Filter = $"(lastUpdate gte \"{since.ToUniversalTime():yyyy-MM-ddTHH:mm:ss}Z\")";
+        Order = "lastUpdate";
+    }
+
     [JsonProperty("add-row-count")] public bool AddRowCount { get; set; } = true;
 
     [JsonProperty("detail")]

--- a/src/Rem.FlexiBeeSDK.Model/Accounting/Ledger/LedgerRequest.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Accounting/Ledger/LedgerRequest.cs
@@ -12,12 +12,12 @@ public class LedgerRequest
         Filter =
             $"((datUcto gte \"{dateFrom:yyyy-MM-dd}\" and datUcto lte \"{dateTo:yyyy-MM-dd}\") {GetAccountFilterString("mdUcet", debitAccountPrefixes)} {GetAccountFilterString("dalUcet", creditAccountPrefixes)} {GetDepartmentFilterString(departmentId)})";
     }
-    
+
     [JsonProperty("add-row-count")] public bool AddRowCount { get; set; } = true;
 
     [JsonProperty("detail")]
     public string Detail { get; set; } =
-        "custom:parSymbol,datVyst,datUcto,doklad,nazFirmy,stredisko(nazev,kod,id),popis,sumTuz,sumMen,mena(kod),kurz,mdUcet(kod,nazev,id),dalUcet(kod,nazev,id),zuctovano,idUcetniDenik,idDokl";
+        "custom:parSymbol,datVyst,datUcto,doklad,nazFirmy,stredisko(nazev,kod,id),popis,sumTuz,sumMen,mena(kod),kurz,mdUcet(kod,nazev,id),dalUcet(kod,nazev,id),zuctovano,idUcetniDenik,idDokl,lastUpdate";
 
     [JsonProperty("limit")] public int Limit { get; set; } = 0;
 
@@ -34,21 +34,21 @@ public class LedgerRequest
     [JsonProperty("no-ext-ids")] public bool NoExtIds { get; set; } = true;
 
     [JsonProperty("@version")] public string Version { get; set; } = "1.0";
-    
+
     [JsonProperty("filter")] public string Filter { get; private set; }
 
     private string GetAccountFilterString(string fieldName, IEnumerable<string>? accountPrefixes = null)
     {
-        if(accountPrefixes == null || !accountPrefixes.Any())
+        if (accountPrefixes == null || !accountPrefixes.Any())
             return String.Empty;
 
         var accounts = accountPrefixes.Select(s => $"{fieldName}.kod begins \"{s}\"");
         return $" and ({string.Join(" or ", accounts)})";
     }
-    
+
     private string GetDepartmentFilterString(string? departmentId = null)
     {
-        if(departmentId == null)
+        if (departmentId == null)
             return String.Empty;
 
         return $" and stredisko.kod = \"{departmentId}\"";

--- a/src/Rem.FlexiBeeSDK.Model/Agenda.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Agenda.cs
@@ -26,7 +26,7 @@ public class Agenda
     public const string Department = "stredisko";
     public const string Sets = "sady-a-komplety";
     public const string IssuedOrders = "objednavka-vydana";
-    
+
     public const string Lots = "sarze-expirace";
-    
+
 }

--- a/src/Rem.FlexiBeeSDK.Model/BoMItemFlexiDto.cs
+++ b/src/Rem.FlexiBeeSDK.Model/BoMItemFlexiDto.cs
@@ -29,27 +29,27 @@ public class BoMItemFlexiDto
     public string Path { get; set; }
 
     public string? ParentCode => ParentProduct?.Code;
-        
+
     [JsonProperty("otecCenik")]
-    public List<BomProductFlexiDto> ParentProductList { get; set; } =  new List<BomProductFlexiDto>();
+    public List<BomProductFlexiDto> ParentProductList { get; set; } = new List<BomProductFlexiDto>();
     public BomProductFlexiDto? ParentProduct => ParentProductList.FirstOrDefault();
     public string? ParentFullName => ParentProduct?.Name;
     public int? ParentTemplateId => Parent?.Id;
-        
-        
-        
+
+
+
     [JsonProperty("cenik")]
     public List<BomProductFlexiDto> Ingredient { get; set; } = new List<BomProductFlexiDto>();
     public string IngredientCode => Ingredient.FirstOrDefault()!.Code;
     public string IngredientFullName => Ingredient.FirstOrDefault()!.Name;
     public bool HasLots => Ingredient.FirstOrDefault()!.HasLots;
     public bool HasExpiration => Ingredient.FirstOrDefault()!.HasExpiration;
-        
+
     [JsonProperty("otec")]
     public List<ParentBomFlexiDto> ParentList { get; set; }
 
     public ParentBomFlexiDto? Parent => ParentList?.FirstOrDefault();
-    
+
     [JsonProperty("otec@showAs")]
     public string ParentTemplateName { get; set; }
 }

--- a/src/Rem.FlexiBeeSDK.Model/BomProductFlexiDto.cs
+++ b/src/Rem.FlexiBeeSDK.Model/BomProductFlexiDto.cs
@@ -12,13 +12,13 @@ public class BomProductFlexiDto
 
     [JsonProperty("nakupCena")]
     public double PurchasePrice { get; set; }
-    
+
     [JsonProperty("skupZboz@internalId")]
     public int ProductTypeId { get; set; }
-    
+
     [JsonProperty("evidSarze")]
     public bool HasLots { get; set; }
-    
+
     [JsonProperty("evidExpir")]
     public bool HasExpiration { get; set; }
 }

--- a/src/Rem.FlexiBeeSDK.Model/Contacts/ContactFlexiDto.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Contacts/ContactFlexiDto.cs
@@ -40,7 +40,7 @@ namespace Rem.FlexiBeeSDK.Model.Contacts
 
         [JsonProperty("stat@showAs", NullValueHandling = NullValueHandling.Ignore)]
         public string CountryShowAs { get; set; }
-        
+
         [JsonProperty("email", NullValueHandling = NullValueHandling.Ignore)]
         public string Email { get; set; }
 

--- a/src/Rem.FlexiBeeSDK.Model/Contacts/ContactListRequest.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Contacts/ContactListRequest.cs
@@ -8,7 +8,7 @@ public class ContactListRequest
 {
     public ContactListRequest(ContactType contactType) : this([contactType])
     {
-        
+
     }
 
     public ContactListRequest(IEnumerable<ContactType> contactTypes)
@@ -37,7 +37,7 @@ public class ContactListRequest
 
         return "vsechno";
     }
-    
+
     private static ContactType ToContactType(string contactType)
     {
         switch (contactType)

--- a/src/Rem.FlexiBeeSDK.Model/Invoices/InvoiceReference.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Invoices/InvoiceReference.cs
@@ -5,7 +5,7 @@ namespace Rem.FlexiBeeSDK.Model.Invoices;
 public class InvoiceReference
 {
     public const string ReferenceTypePayment = "typVazbyDokl.uhrada";
-    
+
     [JsonProperty("id")]
     public int Id { get; set; }
 

--- a/src/Rem.FlexiBeeSDK.Model/Invoices/IssuedInvoiceDetailFlexiDto.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Invoices/IssuedInvoiceDetailFlexiDto.cs
@@ -77,7 +77,7 @@ namespace Rem.FlexiBeeSDK.Model.Invoices
 
         [JsonProperty("duzpUcto", NullValueHandling = NullValueHandling.Ignore)]
         public string DateTaxAcc { get; set; }
-        
+
         [JsonProperty("nazFirmy", NullValueHandling = NullValueHandling.Ignore)]
         public string CompanyName { get; set; }
         [JsonProperty("ulice", NullValueHandling = NullValueHandling.Ignore)]
@@ -105,7 +105,7 @@ namespace Rem.FlexiBeeSDK.Model.Invoices
         [JsonProperty("formaUhradyCis", NullValueHandling = NullValueHandling.Ignore)]
         public object PaymentType { get; set; }
 
-        [JsonProperty("vazby")] public List<InvoiceReference> References { get; set; } = new ();
+        [JsonProperty("vazby")] public List<InvoiceReference> References { get; set; } = new();
 
 
         public List<string> GetBankPaymentsIds() =>
@@ -120,7 +120,7 @@ namespace Rem.FlexiBeeSDK.Model.Invoices
                 .Select(s => s.ReferenceB)
                 .ToList();
 
-       
+
         public void Validate()
         {
             StoreCorrections();
@@ -142,11 +142,11 @@ namespace Rem.FlexiBeeSDK.Model.Invoices
             }
         }
 
-        
-        
+
+
         private void StoreCorrections()
         {
-            foreach(var p in Items)
+            foreach (var p in Items)
                 StoreCorrections(p);
         }
 

--- a/src/Rem.FlexiBeeSDK.Model/Invoices/IssuedInvoiceItemFlexiDto.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Invoices/IssuedInvoiceItemFlexiDto.cs
@@ -42,39 +42,39 @@ namespace Rem.FlexiBeeSDK.Model.Invoices
 
         [JsonProperty("mena@showAs", NullValueHandling = NullValueHandling.Ignore)]
         public string CurrencyShowAs { get; set; }
-        
+
         [JsonProperty("mj", NullValueHandling = NullValueHandling.Ignore)]
         public string MeasureUnit { get; set; }
         [JsonProperty("cenaMj", NullValueHandling = NullValueHandling.Ignore)]
         public decimal PricePerUnit { get; set; }
         [JsonProperty("sumZklMen", NullValueHandling = NullValueHandling.Ignore)]
         public decimal? SumBaseC { get; set; }
-        [JsonProperty("sumZkl", NullValueHandling = NullValueHandling.Ignore)] 
+        [JsonProperty("sumZkl", NullValueHandling = NullValueHandling.Ignore)]
         public decimal? SumBase { get; set; }
         [JsonProperty("typSzbDphK", NullValueHandling = NullValueHandling.Ignore)]
         public string VatRateType { get; set; }
-        [JsonProperty("typCenyDphK", NullValueHandling = NullValueHandling.Ignore)] 
+        [JsonProperty("typCenyDphK", NullValueHandling = NullValueHandling.Ignore)]
         public string PriceVatType { get; set; }
-        
-        [JsonProperty("zklMdUcet", NullValueHandling = NullValueHandling.Ignore)] 
+
+        [JsonProperty("zklMdUcet", NullValueHandling = NullValueHandling.Ignore)]
         public string AccountBaseMd { get; set; }
-        
-        [JsonProperty("zklDalUcet", NullValueHandling = NullValueHandling.Ignore)] 
+
+        [JsonProperty("zklDalUcet", NullValueHandling = NullValueHandling.Ignore)]
         public string AccountBaseDal { get; set; }
-        
-        [JsonProperty("dphMdUcet", NullValueHandling = NullValueHandling.Ignore)] 
+
+        [JsonProperty("dphMdUcet", NullValueHandling = NullValueHandling.Ignore)]
         public string AccountVatMd { get; set; }
-        
-        [JsonProperty("dphDalUcet", NullValueHandling = NullValueHandling.Ignore)] 
+
+        [JsonProperty("dphDalUcet", NullValueHandling = NullValueHandling.Ignore)]
         public string AccountVatDal { get; set; }
-        
-        [JsonProperty("clenKonVykDph", NullValueHandling = NullValueHandling.Ignore)] 
+
+        [JsonProperty("clenKonVykDph", NullValueHandling = NullValueHandling.Ignore)]
         public string CategoryVatReport { get; set; }
 
         [JsonProperty("kopClenKonVykDph", NullValueHandling = NullValueHandling.Ignore)]
         public bool CopyCategoryVatReport { get; set; } = true;
-        
-        [JsonProperty("clenDph", NullValueHandling = NullValueHandling.Ignore)] 
+
+        [JsonProperty("clenDph", NullValueHandling = NullValueHandling.Ignore)]
         public string CategoryVat { get; set; }
 
         [JsonProperty("kopClenDph", NullValueHandling = NullValueHandling.Ignore)]

--- a/src/Rem.FlexiBeeSDK.Model/Invoices/ReceivedInvoiceFlexiDto.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Invoices/ReceivedInvoiceFlexiDto.cs
@@ -4,193 +4,194 @@ using System.Linq;
 using Newtonsoft.Json;
 
 namespace Rem.FlexiBeeSDK.Model.Invoices;
-    public class ReceivedInvoiceFlexiDto
-    {
-        [JsonProperty("id")]
-        public int Id { get; set; }
 
-        [JsonProperty("datVyst")]
-        public DateTime? IssueDate { get; set; }
+public class ReceivedInvoiceFlexiDto
+{
+    [JsonProperty("id")]
+    public int Id { get; set; }
 
-        [JsonProperty("kod")]
-        public string Code { get; set; }
+    [JsonProperty("datVyst")]
+    public DateTime? IssueDate { get; set; }
 
-        [JsonProperty("typDokl@evidencePath")]
-        public string DocumentTypeEvidencePath { get; set; }
+    [JsonProperty("kod")]
+    public string Code { get; set; }
 
-        [JsonProperty("typDokl@internalId")]
-        public int DocumentTypeInternalId { get; set; }
+    [JsonProperty("typDokl@evidencePath")]
+    public string DocumentTypeEvidencePath { get; set; }
 
-        [JsonProperty("typDokl@ref")]
-        public string DocumentTypeRef { get; set; }
+    [JsonProperty("typDokl@internalId")]
+    public int DocumentTypeInternalId { get; set; }
 
-        [JsonProperty("typDokl@showAs")]
-        public string DocumentTypeShowAs { get; set; }
+    [JsonProperty("typDokl@ref")]
+    public string DocumentTypeRef { get; set; }
+
+    [JsonProperty("typDokl@showAs")]
+    public string DocumentTypeShowAs { get; set; }
 
 
-        [JsonProperty("nazFirmy")]
-        public string CompanyName { get; set; }
+    [JsonProperty("nazFirmy")]
+    public string CompanyName { get; set; }
 
-        [JsonProperty("cisDosle")]
-        public string ReceivedNumber { get; set; }
+    [JsonProperty("cisDosle")]
+    public string ReceivedNumber { get; set; }
 
-        [JsonProperty("varSym")]
-        public string VariableSymbol { get; set; }
+    [JsonProperty("varSym")]
+    public string VariableSymbol { get; set; }
 
-        [JsonProperty("stredisko@evidencePath")]
-        public string DepartmentEvidencePath { get; set; }
+    [JsonProperty("stredisko@evidencePath")]
+    public string DepartmentEvidencePath { get; set; }
 
-        [JsonProperty("stredisko@internalId")]
-        public int DepartmentInternalId { get; set; }
+    [JsonProperty("stredisko@internalId")]
+    public int DepartmentInternalId { get; set; }
 
-        [JsonProperty("stredisko@ref")]
-        public string DepartmentRef { get; set; }
+    [JsonProperty("stredisko@ref")]
+    public string DepartmentRef { get; set; }
 
-        [JsonProperty("stredisko@showAs")]
-        public string DepartmentShowAs { get; set; }
+    [JsonProperty("stredisko@showAs")]
+    public string DepartmentShowAs { get; set; }
 
-        [JsonProperty("stredisko")]
-        public List<DepartmentFlexiDto> DepartmentList { get; set; }
-        
-        public DepartmentFlexiDto? Department =>  DepartmentList?.FirstOrDefault();
+    [JsonProperty("stredisko")]
+    public List<DepartmentFlexiDto> DepartmentList { get; set; }
 
-        [JsonProperty("datSplat")]
-        public DateTime? DueDate { get; set; }
+    public DepartmentFlexiDto? Department => DepartmentList?.FirstOrDefault();
 
-        [JsonProperty("sumZklCelkemMen")]
-        public double TotalBaseAmountForeign { get; set; }
+    [JsonProperty("datSplat")]
+    public DateTime? DueDate { get; set; }
 
-        [JsonProperty("sumZklCelkem")]
-        public double TotalBaseAmount { get; set; }
+    [JsonProperty("sumZklCelkemMen")]
+    public double TotalBaseAmountForeign { get; set; }
 
-        [JsonProperty("mena@evidencePath")]
-        public string CurrencyEvidencePath { get; set; }
+    [JsonProperty("sumZklCelkem")]
+    public double TotalBaseAmount { get; set; }
 
-        [JsonProperty("mena@internalId")]
-        public int CurrencyInternalId { get; set; }
+    [JsonProperty("mena@evidencePath")]
+    public string CurrencyEvidencePath { get; set; }
 
-        [JsonProperty("mena@ref")]
-        public string CurrencyRef { get; set; }
+    [JsonProperty("mena@internalId")]
+    public int CurrencyInternalId { get; set; }
 
-        [JsonProperty("mena@showAs")]
-        public string CurrencyShowAs { get; set; }
+    [JsonProperty("mena@ref")]
+    public string CurrencyRef { get; set; }
 
-        [JsonProperty("mena")]
-        public List<CurrencyFlexiDto> CurrencyList { get; set; }
+    [JsonProperty("mena@showAs")]
+    public string CurrencyShowAs { get; set; }
 
-        public CurrencyFlexiDto Currency => CurrencyList.Single();
+    [JsonProperty("mena")]
+    public List<CurrencyFlexiDto> CurrencyList { get; set; }
 
-        
-        [JsonProperty("sumCelkemMen")]
-        public double TotalAmountForeign { get; set; }
+    public CurrencyFlexiDto Currency => CurrencyList.Single();
 
-        [JsonProperty("sumCelkem")]
-        public double TotalAmount { get; set; }
 
-        [JsonProperty("juhSum")]
-        public double RemainingAmount { get; set; }
+    [JsonProperty("sumCelkemMen")]
+    public double TotalAmountForeign { get; set; }
 
-        [JsonProperty("stavUhrK")]
-        public string PaymentStatus { get; set; }
+    [JsonProperty("sumCelkem")]
+    public double TotalAmount { get; set; }
 
-        [JsonProperty("stavUhrK@showAs")]
-        public string PaymentStatusShowAs { get; set; }
+    [JsonProperty("juhSum")]
+    public double RemainingAmount { get; set; }
 
-        [JsonProperty("juhSumMen")]
-        public double RemainingAmountForeign { get; set; }
+    [JsonProperty("stavUhrK")]
+    public string PaymentStatus { get; set; }
 
-        [JsonProperty("storno")]
-        public bool IsCancelled { get; set; }
+    [JsonProperty("stavUhrK@showAs")]
+    public string PaymentStatusShowAs { get; set; }
 
-        [JsonProperty("popis")]
-        public string Description { get; set; }
+    [JsonProperty("juhSumMen")]
+    public double RemainingAmountForeign { get; set; }
 
-        [JsonProperty("buc")]
-        public string BankAccountNumber { get; set; }
+    [JsonProperty("storno")]
+    public bool IsCancelled { get; set; }
 
-        [JsonProperty("smerKod@evidencePath")]
-        public string BankCodeEvidencePath { get; set; }
+    [JsonProperty("popis")]
+    public string Description { get; set; }
 
-        [JsonProperty("smerKod@internalId")]
-        public int BankCodeInternalId { get; set; }
+    [JsonProperty("buc")]
+    public string BankAccountNumber { get; set; }
 
-        [JsonProperty("smerKod@ref")]
-        public string BankCodeRef { get; set; }
+    [JsonProperty("smerKod@evidencePath")]
+    public string BankCodeEvidencePath { get; set; }
 
-        [JsonProperty("smerKod@showAs")]
-        public string BankCodeShowAs { get; set; }
+    [JsonProperty("smerKod@internalId")]
+    public int BankCodeInternalId { get; set; }
 
-        [JsonProperty("iban")]
-        public string IBAN { get; set; }
+    [JsonProperty("smerKod@ref")]
+    public string BankCodeRef { get; set; }
 
-        [JsonProperty("bic")]
-        public string BIC { get; set; }
+    [JsonProperty("smerKod@showAs")]
+    public string BankCodeShowAs { get; set; }
 
-        [JsonProperty("zuctovano")]
-        public bool IsAccounted { get; set; }
+    [JsonProperty("iban")]
+    public string IBAN { get; set; }
 
-        [JsonProperty("datUcto")]
-        public DateTime? AccountingDate { get; set; }
+    [JsonProperty("bic")]
+    public string BIC { get; set; }
 
-        [JsonProperty("typUcOp@evidencePath")]
-        public string AccountingTemplateEvidencePath { get; set; }
+    [JsonProperty("zuctovano")]
+    public bool IsAccounted { get; set; }
 
-        [JsonProperty("typUcOp@internalId")]
-        public int AccountingTemplateInternalId { get; set; }
+    [JsonProperty("datUcto")]
+    public DateTime? AccountingDate { get; set; }
 
-        [JsonProperty("typUcOp@ref")]
-        public string AccountingTemplateRef { get; set; }
+    [JsonProperty("typUcOp@evidencePath")]
+    public string AccountingTemplateEvidencePath { get; set; }
 
-        [JsonProperty("typUcOp@showAs")]
-        public string AccountingTemplateShowAs { get; set; }
+    [JsonProperty("typUcOp@internalId")]
+    public int AccountingTemplateInternalId { get; set; }
 
-        [JsonProperty("typUcOp")]
-        public List<AccountTemplateFlexiDto> AccountingTemplateList { get; set; }
-        
-        public AccountTemplateFlexiDto? AccountingTemplate => AccountingTemplateList.FirstOrDefault();
+    [JsonProperty("typUcOp@ref")]
+    public string AccountingTemplateRef { get; set; }
 
-        [JsonProperty("podpisPrik")]
-        public bool IsSignedCommand { get; set; }
+    [JsonProperty("typUcOp@showAs")]
+    public string AccountingTemplateShowAs { get; set; }
 
-        [JsonProperty("zamekK")]
-        public string LockStatus { get; set; }
+    [JsonProperty("typUcOp")]
+    public List<AccountTemplateFlexiDto> AccountingTemplateList { get; set; }
 
-        [JsonProperty("zamekK@showAs")]
-        public string LockStatusShowAs { get; set; }
+    public AccountTemplateFlexiDto? AccountingTemplate => AccountingTemplateList.FirstOrDefault();
 
-        [JsonProperty("stavOdpocetK")]
-        public string DeductionStatus { get; set; }
+    [JsonProperty("podpisPrik")]
+    public bool IsSignedCommand { get; set; }
 
-        [JsonProperty("stavUzivK")]
-        public string UserStatus { get; set; }
+    [JsonProperty("zamekK")]
+    public string LockStatus { get; set; }
 
-        [JsonProperty("stavUzivK@showAs")]
-        public string UserStatusShowAs { get; set; }
+    [JsonProperty("zamekK@showAs")]
+    public string LockStatusShowAs { get; set; }
 
-        [JsonProperty("bezPolozek")]
-        public bool WithoutItems { get; set; }
+    [JsonProperty("stavOdpocetK")]
+    public string DeductionStatus { get; set; }
 
-        [JsonProperty("firma")]
-        public string Company { get; set; }
+    [JsonProperty("stavUzivK")]
+    public string UserStatus { get; set; }
 
-        [JsonProperty("firma@evidencePath")]
-        public string CompanyEvidencePath { get; set; }
+    [JsonProperty("stavUzivK@showAs")]
+    public string UserStatusShowAs { get; set; }
 
-        [JsonProperty("firma@internalId")]
-        public int CompanyInternalId { get; set; }
+    [JsonProperty("bezPolozek")]
+    public bool WithoutItems { get; set; }
 
-        [JsonProperty("firma@ref")]
-        public string CompanyRef { get; set; }
+    [JsonProperty("firma")]
+    public string Company { get; set; }
 
-        [JsonProperty("firma@showAs")]
-        public string CompanyShowAs { get; set; }
+    [JsonProperty("firma@evidencePath")]
+    public string CompanyEvidencePath { get; set; }
 
-        [JsonProperty("ic")]
-        public string CompanyId { get; set; }
-        
-        [JsonProperty("stitky")]
-        public string Labels { get; set; }
+    [JsonProperty("firma@internalId")]
+    public int CompanyInternalId { get; set; }
 
-        [JsonProperty("polozkyDokladu", NullValueHandling = NullValueHandling.Ignore)]
-        public List<ReceivedInvoiceItemFlexiDto> Items { get; set; }
-    }
+    [JsonProperty("firma@ref")]
+    public string CompanyRef { get; set; }
+
+    [JsonProperty("firma@showAs")]
+    public string CompanyShowAs { get; set; }
+
+    [JsonProperty("ic")]
+    public string CompanyId { get; set; }
+
+    [JsonProperty("stitky")]
+    public string Labels { get; set; }
+
+    [JsonProperty("polozkyDokladu", NullValueHandling = NullValueHandling.Ignore)]
+    public List<ReceivedInvoiceItemFlexiDto> Items { get; set; }
+}

--- a/src/Rem.FlexiBeeSDK.Model/Invoices/ReceivedInvoiceRequest.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Invoices/ReceivedInvoiceRequest.cs
@@ -9,32 +9,32 @@ public class ReceivedInvoiceRequest
     public ReceivedInvoiceRequest(DateTime? dateFrom = null, DateTime? dateTo = null, string? label = null, string? accountingTemplate = null, string? documentNumber = null, string? companyId = null)
     {
         var filters = new List<string>();
-        
+
         if (dateFrom.HasValue && dateTo.HasValue)
         {
             filters.Add($"(datVyst gte \"{dateFrom.Value:yyyy-MM-dd}\" and datVyst lte \"{dateTo.Value:yyyy-MM-dd}\")");
         }
-        
+
         var labelFilter = GetLabelFilterString(label);
         if (!string.IsNullOrEmpty(labelFilter))
             filters.Add(labelFilter);
-            
+
         var accountingTemplateFilter = GetAccountingTemplateFilterString(accountingTemplate);
         if (!string.IsNullOrEmpty(accountingTemplateFilter))
             filters.Add(accountingTemplateFilter);
-            
+
         var documentNumberFilter = GetDocumentNumberFilterString(documentNumber);
         if (!string.IsNullOrEmpty(documentNumberFilter))
             filters.Add(documentNumberFilter);
-            
+
         var companyIdFilter = GetCompanyIdFilterString(companyId);
         if (!string.IsNullOrEmpty(companyIdFilter))
             filters.Add(companyIdFilter);
-        
+
         Filter = filters.Count > 0 ? $"({string.Join(" and ", filters)})" : string.Empty;
     }
-    
-    
+
+
     [JsonProperty("add-row-count")] public bool AddRowCount { get; set; } = true;
 
     [JsonProperty("detail")]
@@ -56,37 +56,37 @@ public class ReceivedInvoiceRequest
     [JsonProperty("no-ext-ids")] public bool NoExtIds { get; set; } = true;
 
     [JsonProperty("@version")] public string Version { get; set; } = "1.0";
-    
+
     [JsonProperty("filter")] public string Filter { get; private set; }
 
-        
+
     private string GetLabelFilterString(string? label = null)
     {
-        if(label == null)
+        if (label == null)
             return String.Empty;
 
         return $"stitky eq \"code:{label}\"";
     }
-    
+
     private string GetAccountingTemplateFilterString(string? accountingTemplate = null)
     {
-        if(accountingTemplate == null)
+        if (accountingTemplate == null)
             return String.Empty;
 
         return $"typUcOp.kod eq \"{accountingTemplate}\"";
     }
-    
+
     private string GetDocumentNumberFilterString(string? documentNumber = null)
     {
-        if(documentNumber == null)
+        if (documentNumber == null)
             return String.Empty;
 
         return $"kod eq \"{documentNumber}\"";
     }
-    
+
     private string GetCompanyIdFilterString(string? companyId = null)
     {
-        if(companyId == null)
+        if (companyId == null)
             return String.Empty;
 
         return $"ic eq \"code:{companyId}\"";

--- a/src/Rem.FlexiBeeSDK.Model/IssuedOrders/CreateIssuedOrderFlexiDto.cs
+++ b/src/Rem.FlexiBeeSDK.Model/IssuedOrders/CreateIssuedOrderFlexiDto.cs
@@ -40,7 +40,7 @@ public class CreateIssuedOrderFlexiDto
 
     [JsonProperty("typDoklNabFak")]
     public string WarehouseDocumentTypeFormated => $"code:{WarehouseDocumentType}";
-    
+
     [JsonIgnore]
     public string WarehouseDocumentType { get; set; }
 

--- a/src/Rem.FlexiBeeSDK.Model/IssuedOrders/FinalizeIssuedOrderFlexiDto.cs
+++ b/src/Rem.FlexiBeeSDK.Model/IssuedOrders/FinalizeIssuedOrderFlexiDto.cs
@@ -11,13 +11,13 @@ public class FinalizeIssuedOrderFlexiDto
 
     public FinalizeIssuedOrderFlexiDto(string orderNumber)
     {
-         Id = $"code:{orderNumber}";   
+        Id = $"code:{orderNumber}";
     }
-    
+
     [JsonProperty("id")] public string Id { get; private set; }
 
     [JsonProperty("realizaceObj@type")] public string FinalizeStockMovementType => "skladovy-pohyb";
 
     [JsonProperty("realizaceObj")]
-    public IssuedOrderStockMovementFlexiDto FinalizeStockMovement { get; set; } =  new IssuedOrderStockMovementFlexiDto();
+    public IssuedOrderStockMovementFlexiDto FinalizeStockMovement { get; set; } = new IssuedOrderStockMovementFlexiDto();
 }

--- a/src/Rem.FlexiBeeSDK.Model/IssuedOrders/FinalizeIssuedOrderItemFlexiDto.cs
+++ b/src/Rem.FlexiBeeSDK.Model/IssuedOrders/FinalizeIssuedOrderItemFlexiDto.cs
@@ -6,7 +6,7 @@ namespace Rem.FlexiBeeSDK.Model.IssuedOrders;
 public class FinalizeIssuedOrderItemFlexiDto
 {
     [JsonProperty("id")] public string Id { get; set; }
-    
+
     [JsonProperty("mj")]
     public double Amount { get; set; }
 

--- a/src/Rem.FlexiBeeSDK.Model/IssuedOrders/IssuedOrderFlexiDto.cs
+++ b/src/Rem.FlexiBeeSDK.Model/IssuedOrders/IssuedOrderFlexiDto.cs
@@ -26,7 +26,7 @@ public class IssuedOrderFlexiDto
 
     [JsonProperty("stredisko")]
     public List<IssuedOrderDepartmentFlexiDto> DepartmentList { get; set; }
-       
+
     [JsonIgnore]
     public IssuedOrderDepartmentFlexiDto? Department => DepartmentList.FirstOrDefault();
 
@@ -51,13 +51,13 @@ public class IssuedOrderFlexiDto
 
     [JsonProperty("stavDoklObch")]
     public List<IssuedOrderStateFlexiDto> StateList { get; set; }
-        
+
     [JsonIgnore]
     IssuedOrderStateFlexiDto State => StateList.First();
 
     [JsonProperty("popis")]
     public string Description { get; set; }
-    
+
     [JsonProperty("polozkyObchDokladu")]
     public List<IssuedOrderItemFlexiDto> Items { get; set; }
 }

--- a/src/Rem.FlexiBeeSDK.Model/IssuedOrders/IssuedOrderItemFlexiDto.cs
+++ b/src/Rem.FlexiBeeSDK.Model/IssuedOrders/IssuedOrderItemFlexiDto.cs
@@ -6,7 +6,7 @@ namespace Rem.FlexiBeeSDK.Model.IssuedOrders;
 public class IssuedOrderItemFlexiDto
 {
     [JsonProperty("id", NullValueHandling = NullValueHandling.Ignore)] public string? Id { get; set; }
-    
+
     [JsonProperty("autogen")] public bool Autogenerate => false;
 
     [JsonProperty("cenJednotka")] public int PriceUnit => 1;
@@ -36,7 +36,7 @@ public class IssuedOrderItemFlexiDto
 
     [JsonProperty("sklad")]
     public string WarehouseCodeFormatted => $"code:{WarehouseCode}";
-    
+
     [JsonIgnore]
     public string WarehouseCode { get; set; }
 

--- a/src/Rem.FlexiBeeSDK.Model/IssuedOrders/IssuedOrderRequest.cs
+++ b/src/Rem.FlexiBeeSDK.Model/IssuedOrders/IssuedOrderRequest.cs
@@ -10,7 +10,7 @@ public class IssuedOrderRequest
         Filter =
             $"(kod eq \"{documentNumber}\")";
     }
-    
+
     public IssuedOrderRequest(int id)
     {
         Filter =
@@ -45,12 +45,12 @@ public class IssuedOrderRequest
     [JsonProperty("no-ext-ids")] public bool NoExtIds { get; set; } = true;
 
     [JsonProperty("@version")] public string Version { get; set; } = "1.0";
-    
+
     [JsonProperty("filter")] public string Filter { get; private set; }
 
     private string GetDocumentTypeFilterString(int? documentTypeId)
     {
-        if(documentTypeId == null)
+        if (documentTypeId == null)
             return String.Empty;
 
         return $" and typDokl = \"{documentTypeId}\"";

--- a/src/Rem.FlexiBeeSDK.Model/IssuedOrders/IssuedOrderStockMovementFlexiDto.cs
+++ b/src/Rem.FlexiBeeSDK.Model/IssuedOrders/IssuedOrderStockMovementFlexiDto.cs
@@ -9,10 +9,10 @@ public class IssuedOrderStockMovementFlexiDto
     public string WarehouseDocumentTypeFormated => $"code:{WarehouseDocumentType}";
     [JsonIgnore]
     public string WarehouseDocumentType { get; set; }
-    
+
     [JsonProperty("sklad")]
     public string WarehouseCodeFormatted => $"code:{WarehouseCode}";
-    
+
     [JsonIgnore]
     public string WarehouseCode { get; set; }
 

--- a/src/Rem.FlexiBeeSDK.Model/Payments/BankPayment.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Payments/BankPayment.cs
@@ -5,623 +5,623 @@ namespace Rem.FlexiBeeSDK.Model.Payments;
 
 public class BankPayment
 {
-        [JsonProperty("id")] public int Id { get; set; }
+    [JsonProperty("id")] public int Id { get; set; }
 
-        // [JsonProperty("id@editable")]
-        // public bool IdEditable { get; set; }
-        //
-        // [JsonProperty("duzpUcto")]
-        // public string DuzpUcto { get; set; }
-        //
-        // [JsonProperty("duzpUcto@visible")]
-        // public bool DuzpUctoVisible { get; set; }
-        //
-        // [JsonProperty("duzpUcto@enabled")]
-        // public bool DuzpUctoEnabled { get; set; }
-        //
-        // [JsonProperty("kurz")]
-        // public double Kurz { get; set; }
-        //
-        // [JsonProperty("kurz@enabled")]
-        // public bool KurzEnabled { get; set; }
-        //
-        // [JsonProperty("uzpTuzemsko")]
-        // public bool UzpTuzemsko { get; set; }
-        //
-        // [JsonProperty("uzpTuzemsko@visible")]
-        // public bool UzpTuzemskoVisible { get; set; }
-        //
-        // [JsonProperty("cisObj")]
-        // public string CisObj { get; set; }
-        //
-        // [JsonProperty("stavUzivK")]
-        // public string StavUzivK { get; set; }
-        //
-        // [JsonProperty("stavUzivK@possibleValues")]
-        // public string StavUzivKPossibleValues { get; set; }
-        //
-        // [JsonProperty("stavUzivK@showAs")]
-        // public string StavUzivKShowAs { get; set; }
-        //
-        // [JsonProperty("dphSniz2Ucet")]
-        // public string DphSniz2Ucet { get; set; }
-        //
-        // [JsonProperty("dphSniz2Ucet@evidencePath")]
-        // public string DphSniz2UcetEvidencePath { get; set; }
-        //
-        // [JsonProperty("sumZklSnizMen")]
-        // public double SumZklSnizMen { get; set; }
-        //
-        // [JsonProperty("sumZklSnizMen@label")]
-        // public string SumZklSnizMenLabel { get; set; }
-        //
-        // [JsonProperty("sumZklSnizMen@enabled")]
-        // public bool SumZklSnizMenEnabled { get; set; }
-        //
-        // [JsonProperty("szbDphZakl")]
-        // public double SzbDphZakl { get; set; }
-        //
-        // [JsonProperty("storno")]
-        // public bool Storno { get; set; }
-        //
-        // [JsonProperty("storno@editable")]
-        // public bool StornoEditable { get; set; }
-        //
-        // [JsonProperty("szbDphSniz")]
-        // public double SzbDphSniz { get; set; }
-        //
-        // [JsonProperty("ic")]
-        // public string Ic { get; set; }
-        //
-        // [JsonProperty("dphSnizUcet")]
-        // public string DphSnizUcet { get; set; }
-        //
-        // [JsonProperty("dphSnizUcet@evidencePath")]
-        // public string DphSnizUcetEvidencePath { get; set; }
-        //
-        // [JsonProperty("zakazka@evidencePath")]
-        // public string ZakazkaEvidencePath { get; set; }
-        //
-        // [JsonProperty("zakazka")]
-        // public List<object> Zakazka { get; set; }
-        //
-        // [JsonProperty("kontaktEmail")]
-        // public string KontaktEmail { get; set; }
-        //
-        // [JsonProperty("typUcOp@evidencePath")]
-        // public string TypUcOpEvidencePath { get; set; }
-        //
-        // [JsonProperty("typUcOp@filterValues")]
-        // public string TypUcOpFilterValues { get; set; }
-        //
-        // [JsonProperty("typUcOp")]
-        // public List<object> TypUcOp { get; set; }
-        //
-        // [JsonProperty("sumOsv")]
-        // public double SumOsv { get; set; }
-        //
-        // [JsonProperty("sumOsv@label")]
-        // public string SumOsvLabel { get; set; }
-        //
-        // [JsonProperty("sumCelkSnizMen")]
-        // public double SumCelkSnizMen { get; set; }
-        //
-        // [JsonProperty("sumCelkSnizMen@enabled")]
-        // public bool SumCelkSnizMenEnabled { get; set; }
-        //
-        // [JsonProperty("nazFirmy")]
-        // public string NazFirmy { get; set; }
-        //
-        // [JsonProperty("eanKod")]
-        // public string EanKod { get; set; }
-        //
-        // [JsonProperty("firma@evidencePath")]
-        // public string FirmaEvidencePath { get; set; }
-        //
-        // [JsonProperty("firma")]
-        // public List<object> Firma { get; set; }
-        //
-        // [JsonProperty("sumCelkSniz2")]
-        // public double SumCelkSniz2 { get; set; }
-        //
-        // [JsonProperty("sumZklZakl")]
-        // public double SumZklZakl { get; set; }
-        //
-        // [JsonProperty("sumZklZakl@label")]
-        // public string SumZklZaklLabel { get; set; }
-        //
-        // [JsonProperty("sumDphSniz")]
-        // public double SumDphSniz { get; set; }
-        //
-        // [JsonProperty("sumCelkem")]
-        // public double SumCelkem { get; set; }
-        //
-        // [JsonProperty("clenKonVykDph")]
-        // public string ClenKonVykDph { get; set; }
-        //
-        // [JsonProperty("clenKonVykDph@evidencePath")]
-        // public string ClenKonVykDphEvidencePath { get; set; }
-        //
-        // [JsonProperty("clenKonVykDph@internalId")]
-        // public int ClenKonVykDphInternalId { get; set; }
-        //
-        // [JsonProperty("clenKonVykDph@ref")]
-        // public string ClenKonVykDphRef { get; set; }
-        //
-        // [JsonProperty("clenKonVykDph@showAs")]
-        // public string ClenKonVykDphShowAs { get; set; }
-        //
-        // [JsonProperty("sumDphZakl")]
-        // public double SumDphZakl { get; set; }
-        //
-        // [JsonProperty("lastUpdate")]
-        // public DateTime LastUpdate { get; set; }
-        //
-        // [JsonProperty("lastUpdate@visible")]
-        // public bool LastUpdateVisible { get; set; }
-        //
-        // [JsonProperty("lastUpdate@editable")]
-        // public bool LastUpdateEditable { get; set; }
-        //
-        // [JsonProperty("lastUpdate@enabled")]
-        // public bool LastUpdateEnabled { get; set; }
-        //
-        // [JsonProperty("ulice")]
-        // public string Ulice { get; set; }
-        //
-        // [JsonProperty("iban")]
-        // public string Iban { get; set; }
-        //
-        // [JsonProperty("sumZklSniz")]
-        // public double SumZklSniz { get; set; }
-        //
-        // [JsonProperty("sumZklSniz@label")]
-        // public string SumZklSnizLabel { get; set; }
-        //
-        // [JsonProperty("konSym")]
-        // public string KonSym { get; set; }
-        //
-        // [JsonProperty("konSym@evidencePath")]
-        // public string KonSymEvidencePath { get; set; }
-        //
-        // [JsonProperty("konSym@internalId")]
-        // public int KonSymInternalId { get; set; }
-        //
-        // [JsonProperty("konSym@ref")]
-        // public string KonSymRef { get; set; }
-        //
-        // [JsonProperty("konSym@showAs")]
-        // public string KonSymShowAs { get; set; }
-        //
-        // [JsonProperty("clenDph")]
-        // public string ClenDph { get; set; }
-        //
-        // [JsonProperty("clenDph@evidencePath")]
-        // public string ClenDphEvidencePath { get; set; }
-        //
-        // [JsonProperty("clenDph@internalId")]
-        // public int ClenDphInternalId { get; set; }
-        //
-        // [JsonProperty("clenDph@ref")]
-        // public string ClenDphRef { get; set; }
-        //
-        // [JsonProperty("clenDph@showAs")]
-        // public string ClenDphShowAs { get; set; }
-        //
-        // [JsonProperty("kontaktJmeno")]
-        // public string KontaktJmeno { get; set; }
-        //
-        // [JsonProperty("banka@evidencePath")]
-        // public string BankaEvidencePath { get; set; }
-        //
-        // [JsonProperty("banka@internalId")]
-        // public int BankaInternalId { get; set; }
-        //
-        // [JsonProperty("banka@ref")]
-        // public string BankaRef { get; set; }
-        //
-        // [JsonProperty("banka@showAs")]
-        // public string BankaShowAs { get; set; }
-        //
-        // [JsonProperty("banka")]
-        // public List<Banka> Banka { get; set; }
-        //
-        // [JsonProperty("vyloucitSaldo")]
-        // public bool VyloucitSaldo { get; set; }
-        //
-        // [JsonProperty("kontaktOsoba@evidencePath")]
-        // public string KontaktOsobaEvidencePath { get; set; }
-        //
-        // [JsonProperty("kontaktOsoba")]
-        // public List<object> KontaktOsoba { get; set; }
-        //
-        // [JsonProperty("specSym")]
-        // public string SpecSym { get; set; }
-        //
-        // [JsonProperty("cisDosle")]
-        // public string CisDosle { get; set; }
-        //
-        // [JsonProperty("smerKod@evidencePath")]
-        // public string SmerKodEvidencePath { get; set; }
-        //
-        // [JsonProperty("smerKod@internalId")]
-        // public int SmerKodInternalId { get; set; }
-        //
-        // [JsonProperty("smerKod@ref")]
-        // public string SmerKodRef { get; set; }
-        //
-        // [JsonProperty("smerKod@showAs")]
-        // public string SmerKodShowAs { get; set; }
-        //
-        // [JsonProperty("smerKod")]
-        // public List<SmerKod> SmerKod { get; set; }
-        //
-        // [JsonProperty("sumZklSniz2Men")]
-        // public double SumZklSniz2Men { get; set; }
-        //
-        // [JsonProperty("sumZklSniz2Men@label")]
-        // public string SumZklSniz2MenLabel { get; set; }
-        //
-        // [JsonProperty("sumZklSniz2Men@enabled")]
-        // public bool SumZklSniz2MenEnabled { get; set; }
-        //
-        // [JsonProperty("typDokl@evidencePath")]
-        // public string TypDoklEvidencePath { get; set; }
-        //
-        // [JsonProperty("typDokl@internalId")]
-        // public int TypDoklInternalId { get; set; }
-        //
-        // [JsonProperty("typDokl@ref")]
-        // public string TypDoklRef { get; set; }
-        //
-        // [JsonProperty("typDokl@showAs")]
-        // public string TypDoklShowAs { get; set; }
-        //
-        // [JsonProperty("typDokl")]
-        // public List<TypDokl> TypDokl { get; set; }
-        //
-        // [JsonProperty("szbDphSniz2")]
-        // public double SzbDphSniz2 { get; set; }
-        //
-        // [JsonProperty("sumZklSniz2")]
-        // public double SumZklSniz2 { get; set; }
-        //
-        // [JsonProperty("sumZklSniz2@label")]
-        // public string SumZklSniz2Label { get; set; }
-        //
-        // [JsonProperty("protiUcet")]
-        // public string ProtiUcet { get; set; }
-        //
-        // [JsonProperty("protiUcet@evidencePath")]
-        // public string ProtiUcetEvidencePath { get; set; }
-        //
-        // [JsonProperty("protiUcet@internalId")]
-        // public int ProtiUcetInternalId { get; set; }
-        //
-        // [JsonProperty("protiUcet@ref")]
-        // public string ProtiUcetRef { get; set; }
-        //
-        // [JsonProperty("protiUcet@showAs")]
-        // public string ProtiUcetShowAs { get; set; }
-        //
-        // [JsonProperty("sparovano")]
-        // public bool Sparovano { get; set; }
-        //
-        // [JsonProperty("sparovano@editable")]
-        // public bool SparovanoEditable { get; set; }
-        //
-        // [JsonProperty("zodpOsoba@evidencePath")]
-        // public string ZodpOsobaEvidencePath { get; set; }
-        //
-        // [JsonProperty("zodpOsoba@internalId")]
-        // public int ZodpOsobaInternalId { get; set; }
-        //
-        // [JsonProperty("zodpOsoba@ref")]
-        // public string ZodpOsobaRef { get; set; }
-        //
-        // [JsonProperty("zodpOsoba@showAs")]
-        // public string ZodpOsobaShowAs { get; set; }
-        //
-        // [JsonProperty("zodpOsoba")]
-        // public List<ZodpOsoba> ZodpOsoba { get; set; }
-        //
-        // [JsonProperty("sumDphSniz2")]
-        // public double SumDphSniz2 { get; set; }
-        //
-        // [JsonProperty("stat@evidencePath")]
-        // public string StatEvidencePath { get; set; }
-        //
-        // [JsonProperty("stat@internalId")]
-        // public int StatInternalId { get; set; }
-        //
-        // [JsonProperty("stat@ref")]
-        // public string StatRef { get; set; }
-        //
-        // [JsonProperty("stat@showAs")]
-        // public string StatShowAs { get; set; }
-        //
-        // [JsonProperty("stat")]
-        // public List<Stat> Stat { get; set; }
-        //
-        // [JsonProperty("kurzMnozstvi")]
-        // public double KurzMnozstvi { get; set; }
-        //
-        // [JsonProperty("kurzMnozstvi@enabled")]
-        // public bool KurzMnozstviEnabled { get; set; }
-        //
-        // [JsonProperty("popis")]
-        // public string Popis { get; set; }
-        //
-        // [JsonProperty("stitky")]
-        // public string Stitky { get; set; }
-        //
-        // [JsonProperty("buc")]
-        // public string Buc { get; set; }
-        //
-        // [JsonProperty("mena@evidencePath")]
-        // public string MenaEvidencePath { get; set; }
-        //
-        // [JsonProperty("mena@internalId")]
-        // public int MenaInternalId { get; set; }
-        //
-        // [JsonProperty("mena@ref")]
-        // public string MenaRef { get; set; }
-        //
-        // [JsonProperty("mena@showAs")]
-        // public string MenaShowAs { get; set; }
-        //
-        // [JsonProperty("mena")]
-        // public List<Mena> Mena { get; set; }
-        //
-        // [JsonProperty("dphZaklUcet")]
-        // public string DphZaklUcet { get; set; }
-        //
-        // [JsonProperty("dphZaklUcet@evidencePath")]
-        // public string DphZaklUcetEvidencePath { get; set; }
-        //
-        // [JsonProperty("sumDphZaklMen")]
-        // public double SumDphZaklMen { get; set; }
-        //
-        // [JsonProperty("sumDphZaklMen@enabled")]
-        // public bool SumDphZaklMenEnabled { get; set; }
-        //
-        // [JsonProperty("dic")]
-        // public string Dic { get; set; }
-        //
-        // [JsonProperty("kod")]
-        // public string Kod { get; set; }
-        //
-        // [JsonProperty("statDph")]
-        // public string StatDph { get; set; }
-        //
-        // [JsonProperty("statDph@evidencePath")]
-        // public string StatDphEvidencePath { get; set; }
-        //
-        // [JsonProperty("statDph@internalId")]
-        // public int StatDphInternalId { get; set; }
-        //
-        // [JsonProperty("statDph@ref")]
-        // public string StatDphRef { get; set; }
-        //
-        // [JsonProperty("statDph@showAs")]
-        // public string StatDphShowAs { get; set; }
-        //
-        // [JsonProperty("sumCelkZaklMen")]
-        // public double SumCelkZaklMen { get; set; }
-        //
-        // [JsonProperty("sumCelkZaklMen@enabled")]
-        // public bool SumCelkZaklMenEnabled { get; set; }
-        //
-        // [JsonProperty("sumOsvMen")]
-        // public double SumOsvMen { get; set; }
-        //
-        // [JsonProperty("sumOsvMen@label")]
-        // public string SumOsvMenLabel { get; set; }
-        //
-        // [JsonProperty("sumOsvMen@enabled")]
-        // public bool SumOsvMenEnabled { get; set; }
-        //
-        // [JsonProperty("duzpPuv")]
-        // public string DuzpPuv { get; set; }
-        //
-        // [JsonProperty("source")]
-        // public string Source { get; set; }
-        //
-        // [JsonProperty("typPohybuK")]
-        // public string TypPohybuK { get; set; }
-        //
-        // [JsonProperty("typPohybuK@possibleValues")]
-        // public string TypPohybuKPossibleValues { get; set; }
-        //
-        // [JsonProperty("typPohybuK@showAs")]
-        // public string TypPohybuKShowAs { get; set; }
-        //
-        // [JsonProperty("sumCelkSniz2Men")]
-        // public double SumCelkSniz2Men { get; set; }
-        //
-        // [JsonProperty("sumCelkSniz2Men@enabled")]
-        // public bool SumCelkSniz2MenEnabled { get; set; }
-        //
-        // [JsonProperty("sumCelkemMen")]
-        // public double SumCelkemMen { get; set; }
-        //
-        // [JsonProperty("sumCelkemMen@enabled")]
-        // public bool SumCelkemMenEnabled { get; set; }
-        //
-        // [JsonProperty("vypisCisDokl")]
-        // public string VypisCisDokl { get; set; }
-        //
-        // [JsonProperty("datVyst")]
-        // public string DatVyst { get; set; }
-        //
-        // [JsonProperty("poznam")]
-        // public string Poznam { get; set; }
-        //
-        // [JsonProperty("sumDphSnizMen")]
-        // public double SumDphSnizMen { get; set; }
-        //
-        // [JsonProperty("sumDphSnizMen@enabled")]
-        // public bool SumDphSnizMenEnabled { get; set; }
-        //
-        // [JsonProperty("zapocet")]
-        // public bool Zapocet { get; set; }
-        //
-        // [JsonProperty("sumCelkSniz")]
-        // public double SumCelkSniz { get; set; }
-        //
-        // [JsonProperty("sumCelkZakl")]
-        // public double SumCelkZakl { get; set; }
-        //
-        // [JsonProperty("mesto")]
-        // public string Mesto { get; set; }
-        //
-        // [JsonProperty("datUcto")]
-        // public string DatUcto { get; set; }
-        //
-        // [JsonProperty("psc")]
-        // public string Psc { get; set; }
-        //
-        // [JsonProperty("zamekK")]
-        // public string ZamekK { get; set; }
-        //
-        // [JsonProperty("zamekK@possibleValues")]
-        // public string ZamekKPossibleValues { get; set; }
-        //
-        // [JsonProperty("zamekK@showAs")]
-        // public string ZamekKShowAs { get; set; }
-        //
-        // [JsonProperty("zamekK@editable")]
-        // public bool ZamekKEditable { get; set; }
-        //
-        // [JsonProperty("stredisko@evidencePath")]
-        // public string StrediskoEvidencePath { get; set; }
-        //
-        // [JsonProperty("stredisko@internalId")]
-        // public int StrediskoInternalId { get; set; }
-        //
-        // [JsonProperty("stredisko@ref")]
-        // public string StrediskoRef { get; set; }
-        //
-        // [JsonProperty("stredisko@showAs")]
-        // public string StrediskoShowAs { get; set; }
-        //
-        // [JsonProperty("jakUhrK")]
-        // public string JakUhrK { get; set; }
-        //
-        // [JsonProperty("jakUhrK@possibleValues")]
-        // public string JakUhrKPossibleValues { get; set; }
-        //
-        // [JsonProperty("varSym")]
-        // public string VarSym { get; set; }
-        //
-        // [JsonProperty("kontaktTel")]
-        // public string KontaktTel { get; set; }
-        //
-        // [JsonProperty("banSpojDod@evidencePath")]
-        // public string BanSpojDodEvidencePath { get; set; }
-        //
-        // [JsonProperty("banSpojDod@filterValues")]
-        // public string BanSpojDodFilterValues { get; set; }
-        //
-        // [JsonProperty("banSpojDod@if-not-found")]
-        // public string BanSpojDodIfNotFound { get; set; }
-        //
-        // [JsonProperty("banSpojDod")]
-        // public List<object> BanSpojDod { get; set; }
-        //
-        // [JsonProperty("uzivatel")]
-        // public string Uzivatel { get; set; }
-        //
-        // [JsonProperty("uzivatel@evidencePath")]
-        // public string UzivatelEvidencePath { get; set; }
-        //
-        // [JsonProperty("uzivatel@internalId")]
-        // public int UzivatelInternalId { get; set; }
-        //
-        // [JsonProperty("uzivatel@ref")]
-        // public string UzivatelRef { get; set; }
-        //
-        // [JsonProperty("uzivatel@showAs")]
-        // public string UzivatelShowAs { get; set; }
-        //
-        // [JsonProperty("uzivatel@editable")]
-        // public bool UzivatelEditable { get; set; }
-        //
-        // [JsonProperty("rada")]
-        // public string Rada { get; set; }
-        //
-        // [JsonProperty("rada@evidencePath")]
-        // public string RadaEvidencePath { get; set; }
-        //
-        // [JsonProperty("rada@internalId")]
-        // public int RadaInternalId { get; set; }
-        //
-        // [JsonProperty("rada@ref")]
-        // public string RadaRef { get; set; }
-        //
-        // [JsonProperty("rada@showAs")]
-        // public string RadaShowAs { get; set; }
-        //
-        // [JsonProperty("rada@if-not-found")]
-        // public string RadaIfNotFound { get; set; }
-        //
-        // [JsonProperty("sumZklZaklMen")]
-        // public double SumZklZaklMen { get; set; }
-        //
-        // [JsonProperty("sumZklZaklMen@label")]
-        // public string SumZklZaklMenLabel { get; set; }
-        //
-        // [JsonProperty("sumZklZaklMen@enabled")]
-        // public bool SumZklZaklMenEnabled { get; set; }
-        //
-        // [JsonProperty("primUcet")]
-        // public string PrimUcet { get; set; }
-        //
-        // [JsonProperty("primUcet@evidencePath")]
-        // public string PrimUcetEvidencePath { get; set; }
-        //
-        // [JsonProperty("primUcet@internalId")]
-        // public int PrimUcetInternalId { get; set; }
-        //
-        // [JsonProperty("primUcet@ref")]
-        // public string PrimUcetRef { get; set; }
-        //
-        // [JsonProperty("primUcet@showAs")]
-        // public string PrimUcetShowAs { get; set; }
-        //
-        // [JsonProperty("cinnost")]
-        // public string Cinnost { get; set; }
-        //
-        // [JsonProperty("cinnost@evidencePath")]
-        // public string CinnostEvidencePath { get; set; }
-        //
-        // [JsonProperty("cisSouhrnne")]
-        // public string CisSouhrnne { get; set; }
-        //
-        // [JsonProperty("cisSouhrnne@editable")]
-        // public bool CisSouhrnneEditable { get; set; }
-        //
-        // [JsonProperty("zuctovano")]
-        // public bool Zuctovano { get; set; }
-        //
-        // [JsonProperty("zuctovano@editable")]
-        // public bool ZuctovanoEditable { get; set; }
-        //
-        // [JsonProperty("bic")]
-        // public string Bic { get; set; }
-        //
-        // [JsonProperty("sumDphSniz2Men")]
-        // public double SumDphSniz2Men { get; set; }
-        //
-        // [JsonProperty("sumDphSniz2Men@enabled")]
-        // public bool SumDphSniz2MenEnabled { get; set; }
-        //
-        // [JsonProperty("prilohy")]
-        // public List<object> Prilohy { get; set; }
-        //
-        // [JsonProperty("vazby")]
-        // public List<object> Vazby { get; set; }
-        //
-        // [JsonProperty("smerKod@editable")]
-        // public bool SmerKodEditable { get; set; }
+    // [JsonProperty("id@editable")]
+    // public bool IdEditable { get; set; }
+    //
+    // [JsonProperty("duzpUcto")]
+    // public string DuzpUcto { get; set; }
+    //
+    // [JsonProperty("duzpUcto@visible")]
+    // public bool DuzpUctoVisible { get; set; }
+    //
+    // [JsonProperty("duzpUcto@enabled")]
+    // public bool DuzpUctoEnabled { get; set; }
+    //
+    // [JsonProperty("kurz")]
+    // public double Kurz { get; set; }
+    //
+    // [JsonProperty("kurz@enabled")]
+    // public bool KurzEnabled { get; set; }
+    //
+    // [JsonProperty("uzpTuzemsko")]
+    // public bool UzpTuzemsko { get; set; }
+    //
+    // [JsonProperty("uzpTuzemsko@visible")]
+    // public bool UzpTuzemskoVisible { get; set; }
+    //
+    // [JsonProperty("cisObj")]
+    // public string CisObj { get; set; }
+    //
+    // [JsonProperty("stavUzivK")]
+    // public string StavUzivK { get; set; }
+    //
+    // [JsonProperty("stavUzivK@possibleValues")]
+    // public string StavUzivKPossibleValues { get; set; }
+    //
+    // [JsonProperty("stavUzivK@showAs")]
+    // public string StavUzivKShowAs { get; set; }
+    //
+    // [JsonProperty("dphSniz2Ucet")]
+    // public string DphSniz2Ucet { get; set; }
+    //
+    // [JsonProperty("dphSniz2Ucet@evidencePath")]
+    // public string DphSniz2UcetEvidencePath { get; set; }
+    //
+    // [JsonProperty("sumZklSnizMen")]
+    // public double SumZklSnizMen { get; set; }
+    //
+    // [JsonProperty("sumZklSnizMen@label")]
+    // public string SumZklSnizMenLabel { get; set; }
+    //
+    // [JsonProperty("sumZklSnizMen@enabled")]
+    // public bool SumZklSnizMenEnabled { get; set; }
+    //
+    // [JsonProperty("szbDphZakl")]
+    // public double SzbDphZakl { get; set; }
+    //
+    // [JsonProperty("storno")]
+    // public bool Storno { get; set; }
+    //
+    // [JsonProperty("storno@editable")]
+    // public bool StornoEditable { get; set; }
+    //
+    // [JsonProperty("szbDphSniz")]
+    // public double SzbDphSniz { get; set; }
+    //
+    // [JsonProperty("ic")]
+    // public string Ic { get; set; }
+    //
+    // [JsonProperty("dphSnizUcet")]
+    // public string DphSnizUcet { get; set; }
+    //
+    // [JsonProperty("dphSnizUcet@evidencePath")]
+    // public string DphSnizUcetEvidencePath { get; set; }
+    //
+    // [JsonProperty("zakazka@evidencePath")]
+    // public string ZakazkaEvidencePath { get; set; }
+    //
+    // [JsonProperty("zakazka")]
+    // public List<object> Zakazka { get; set; }
+    //
+    // [JsonProperty("kontaktEmail")]
+    // public string KontaktEmail { get; set; }
+    //
+    // [JsonProperty("typUcOp@evidencePath")]
+    // public string TypUcOpEvidencePath { get; set; }
+    //
+    // [JsonProperty("typUcOp@filterValues")]
+    // public string TypUcOpFilterValues { get; set; }
+    //
+    // [JsonProperty("typUcOp")]
+    // public List<object> TypUcOp { get; set; }
+    //
+    // [JsonProperty("sumOsv")]
+    // public double SumOsv { get; set; }
+    //
+    // [JsonProperty("sumOsv@label")]
+    // public string SumOsvLabel { get; set; }
+    //
+    // [JsonProperty("sumCelkSnizMen")]
+    // public double SumCelkSnizMen { get; set; }
+    //
+    // [JsonProperty("sumCelkSnizMen@enabled")]
+    // public bool SumCelkSnizMenEnabled { get; set; }
+    //
+    // [JsonProperty("nazFirmy")]
+    // public string NazFirmy { get; set; }
+    //
+    // [JsonProperty("eanKod")]
+    // public string EanKod { get; set; }
+    //
+    // [JsonProperty("firma@evidencePath")]
+    // public string FirmaEvidencePath { get; set; }
+    //
+    // [JsonProperty("firma")]
+    // public List<object> Firma { get; set; }
+    //
+    // [JsonProperty("sumCelkSniz2")]
+    // public double SumCelkSniz2 { get; set; }
+    //
+    // [JsonProperty("sumZklZakl")]
+    // public double SumZklZakl { get; set; }
+    //
+    // [JsonProperty("sumZklZakl@label")]
+    // public string SumZklZaklLabel { get; set; }
+    //
+    // [JsonProperty("sumDphSniz")]
+    // public double SumDphSniz { get; set; }
+    //
+    // [JsonProperty("sumCelkem")]
+    // public double SumCelkem { get; set; }
+    //
+    // [JsonProperty("clenKonVykDph")]
+    // public string ClenKonVykDph { get; set; }
+    //
+    // [JsonProperty("clenKonVykDph@evidencePath")]
+    // public string ClenKonVykDphEvidencePath { get; set; }
+    //
+    // [JsonProperty("clenKonVykDph@internalId")]
+    // public int ClenKonVykDphInternalId { get; set; }
+    //
+    // [JsonProperty("clenKonVykDph@ref")]
+    // public string ClenKonVykDphRef { get; set; }
+    //
+    // [JsonProperty("clenKonVykDph@showAs")]
+    // public string ClenKonVykDphShowAs { get; set; }
+    //
+    // [JsonProperty("sumDphZakl")]
+    // public double SumDphZakl { get; set; }
+    //
+    // [JsonProperty("lastUpdate")]
+    // public DateTime LastUpdate { get; set; }
+    //
+    // [JsonProperty("lastUpdate@visible")]
+    // public bool LastUpdateVisible { get; set; }
+    //
+    // [JsonProperty("lastUpdate@editable")]
+    // public bool LastUpdateEditable { get; set; }
+    //
+    // [JsonProperty("lastUpdate@enabled")]
+    // public bool LastUpdateEnabled { get; set; }
+    //
+    // [JsonProperty("ulice")]
+    // public string Ulice { get; set; }
+    //
+    // [JsonProperty("iban")]
+    // public string Iban { get; set; }
+    //
+    // [JsonProperty("sumZklSniz")]
+    // public double SumZklSniz { get; set; }
+    //
+    // [JsonProperty("sumZklSniz@label")]
+    // public string SumZklSnizLabel { get; set; }
+    //
+    // [JsonProperty("konSym")]
+    // public string KonSym { get; set; }
+    //
+    // [JsonProperty("konSym@evidencePath")]
+    // public string KonSymEvidencePath { get; set; }
+    //
+    // [JsonProperty("konSym@internalId")]
+    // public int KonSymInternalId { get; set; }
+    //
+    // [JsonProperty("konSym@ref")]
+    // public string KonSymRef { get; set; }
+    //
+    // [JsonProperty("konSym@showAs")]
+    // public string KonSymShowAs { get; set; }
+    //
+    // [JsonProperty("clenDph")]
+    // public string ClenDph { get; set; }
+    //
+    // [JsonProperty("clenDph@evidencePath")]
+    // public string ClenDphEvidencePath { get; set; }
+    //
+    // [JsonProperty("clenDph@internalId")]
+    // public int ClenDphInternalId { get; set; }
+    //
+    // [JsonProperty("clenDph@ref")]
+    // public string ClenDphRef { get; set; }
+    //
+    // [JsonProperty("clenDph@showAs")]
+    // public string ClenDphShowAs { get; set; }
+    //
+    // [JsonProperty("kontaktJmeno")]
+    // public string KontaktJmeno { get; set; }
+    //
+    // [JsonProperty("banka@evidencePath")]
+    // public string BankaEvidencePath { get; set; }
+    //
+    // [JsonProperty("banka@internalId")]
+    // public int BankaInternalId { get; set; }
+    //
+    // [JsonProperty("banka@ref")]
+    // public string BankaRef { get; set; }
+    //
+    // [JsonProperty("banka@showAs")]
+    // public string BankaShowAs { get; set; }
+    //
+    // [JsonProperty("banka")]
+    // public List<Banka> Banka { get; set; }
+    //
+    // [JsonProperty("vyloucitSaldo")]
+    // public bool VyloucitSaldo { get; set; }
+    //
+    // [JsonProperty("kontaktOsoba@evidencePath")]
+    // public string KontaktOsobaEvidencePath { get; set; }
+    //
+    // [JsonProperty("kontaktOsoba")]
+    // public List<object> KontaktOsoba { get; set; }
+    //
+    // [JsonProperty("specSym")]
+    // public string SpecSym { get; set; }
+    //
+    // [JsonProperty("cisDosle")]
+    // public string CisDosle { get; set; }
+    //
+    // [JsonProperty("smerKod@evidencePath")]
+    // public string SmerKodEvidencePath { get; set; }
+    //
+    // [JsonProperty("smerKod@internalId")]
+    // public int SmerKodInternalId { get; set; }
+    //
+    // [JsonProperty("smerKod@ref")]
+    // public string SmerKodRef { get; set; }
+    //
+    // [JsonProperty("smerKod@showAs")]
+    // public string SmerKodShowAs { get; set; }
+    //
+    // [JsonProperty("smerKod")]
+    // public List<SmerKod> SmerKod { get; set; }
+    //
+    // [JsonProperty("sumZklSniz2Men")]
+    // public double SumZklSniz2Men { get; set; }
+    //
+    // [JsonProperty("sumZklSniz2Men@label")]
+    // public string SumZklSniz2MenLabel { get; set; }
+    //
+    // [JsonProperty("sumZklSniz2Men@enabled")]
+    // public bool SumZklSniz2MenEnabled { get; set; }
+    //
+    // [JsonProperty("typDokl@evidencePath")]
+    // public string TypDoklEvidencePath { get; set; }
+    //
+    // [JsonProperty("typDokl@internalId")]
+    // public int TypDoklInternalId { get; set; }
+    //
+    // [JsonProperty("typDokl@ref")]
+    // public string TypDoklRef { get; set; }
+    //
+    // [JsonProperty("typDokl@showAs")]
+    // public string TypDoklShowAs { get; set; }
+    //
+    // [JsonProperty("typDokl")]
+    // public List<TypDokl> TypDokl { get; set; }
+    //
+    // [JsonProperty("szbDphSniz2")]
+    // public double SzbDphSniz2 { get; set; }
+    //
+    // [JsonProperty("sumZklSniz2")]
+    // public double SumZklSniz2 { get; set; }
+    //
+    // [JsonProperty("sumZklSniz2@label")]
+    // public string SumZklSniz2Label { get; set; }
+    //
+    // [JsonProperty("protiUcet")]
+    // public string ProtiUcet { get; set; }
+    //
+    // [JsonProperty("protiUcet@evidencePath")]
+    // public string ProtiUcetEvidencePath { get; set; }
+    //
+    // [JsonProperty("protiUcet@internalId")]
+    // public int ProtiUcetInternalId { get; set; }
+    //
+    // [JsonProperty("protiUcet@ref")]
+    // public string ProtiUcetRef { get; set; }
+    //
+    // [JsonProperty("protiUcet@showAs")]
+    // public string ProtiUcetShowAs { get; set; }
+    //
+    // [JsonProperty("sparovano")]
+    // public bool Sparovano { get; set; }
+    //
+    // [JsonProperty("sparovano@editable")]
+    // public bool SparovanoEditable { get; set; }
+    //
+    // [JsonProperty("zodpOsoba@evidencePath")]
+    // public string ZodpOsobaEvidencePath { get; set; }
+    //
+    // [JsonProperty("zodpOsoba@internalId")]
+    // public int ZodpOsobaInternalId { get; set; }
+    //
+    // [JsonProperty("zodpOsoba@ref")]
+    // public string ZodpOsobaRef { get; set; }
+    //
+    // [JsonProperty("zodpOsoba@showAs")]
+    // public string ZodpOsobaShowAs { get; set; }
+    //
+    // [JsonProperty("zodpOsoba")]
+    // public List<ZodpOsoba> ZodpOsoba { get; set; }
+    //
+    // [JsonProperty("sumDphSniz2")]
+    // public double SumDphSniz2 { get; set; }
+    //
+    // [JsonProperty("stat@evidencePath")]
+    // public string StatEvidencePath { get; set; }
+    //
+    // [JsonProperty("stat@internalId")]
+    // public int StatInternalId { get; set; }
+    //
+    // [JsonProperty("stat@ref")]
+    // public string StatRef { get; set; }
+    //
+    // [JsonProperty("stat@showAs")]
+    // public string StatShowAs { get; set; }
+    //
+    // [JsonProperty("stat")]
+    // public List<Stat> Stat { get; set; }
+    //
+    // [JsonProperty("kurzMnozstvi")]
+    // public double KurzMnozstvi { get; set; }
+    //
+    // [JsonProperty("kurzMnozstvi@enabled")]
+    // public bool KurzMnozstviEnabled { get; set; }
+    //
+    // [JsonProperty("popis")]
+    // public string Popis { get; set; }
+    //
+    // [JsonProperty("stitky")]
+    // public string Stitky { get; set; }
+    //
+    // [JsonProperty("buc")]
+    // public string Buc { get; set; }
+    //
+    // [JsonProperty("mena@evidencePath")]
+    // public string MenaEvidencePath { get; set; }
+    //
+    // [JsonProperty("mena@internalId")]
+    // public int MenaInternalId { get; set; }
+    //
+    // [JsonProperty("mena@ref")]
+    // public string MenaRef { get; set; }
+    //
+    // [JsonProperty("mena@showAs")]
+    // public string MenaShowAs { get; set; }
+    //
+    // [JsonProperty("mena")]
+    // public List<Mena> Mena { get; set; }
+    //
+    // [JsonProperty("dphZaklUcet")]
+    // public string DphZaklUcet { get; set; }
+    //
+    // [JsonProperty("dphZaklUcet@evidencePath")]
+    // public string DphZaklUcetEvidencePath { get; set; }
+    //
+    // [JsonProperty("sumDphZaklMen")]
+    // public double SumDphZaklMen { get; set; }
+    //
+    // [JsonProperty("sumDphZaklMen@enabled")]
+    // public bool SumDphZaklMenEnabled { get; set; }
+    //
+    // [JsonProperty("dic")]
+    // public string Dic { get; set; }
+    //
+    // [JsonProperty("kod")]
+    // public string Kod { get; set; }
+    //
+    // [JsonProperty("statDph")]
+    // public string StatDph { get; set; }
+    //
+    // [JsonProperty("statDph@evidencePath")]
+    // public string StatDphEvidencePath { get; set; }
+    //
+    // [JsonProperty("statDph@internalId")]
+    // public int StatDphInternalId { get; set; }
+    //
+    // [JsonProperty("statDph@ref")]
+    // public string StatDphRef { get; set; }
+    //
+    // [JsonProperty("statDph@showAs")]
+    // public string StatDphShowAs { get; set; }
+    //
+    // [JsonProperty("sumCelkZaklMen")]
+    // public double SumCelkZaklMen { get; set; }
+    //
+    // [JsonProperty("sumCelkZaklMen@enabled")]
+    // public bool SumCelkZaklMenEnabled { get; set; }
+    //
+    // [JsonProperty("sumOsvMen")]
+    // public double SumOsvMen { get; set; }
+    //
+    // [JsonProperty("sumOsvMen@label")]
+    // public string SumOsvMenLabel { get; set; }
+    //
+    // [JsonProperty("sumOsvMen@enabled")]
+    // public bool SumOsvMenEnabled { get; set; }
+    //
+    // [JsonProperty("duzpPuv")]
+    // public string DuzpPuv { get; set; }
+    //
+    // [JsonProperty("source")]
+    // public string Source { get; set; }
+    //
+    // [JsonProperty("typPohybuK")]
+    // public string TypPohybuK { get; set; }
+    //
+    // [JsonProperty("typPohybuK@possibleValues")]
+    // public string TypPohybuKPossibleValues { get; set; }
+    //
+    // [JsonProperty("typPohybuK@showAs")]
+    // public string TypPohybuKShowAs { get; set; }
+    //
+    // [JsonProperty("sumCelkSniz2Men")]
+    // public double SumCelkSniz2Men { get; set; }
+    //
+    // [JsonProperty("sumCelkSniz2Men@enabled")]
+    // public bool SumCelkSniz2MenEnabled { get; set; }
+    //
+    // [JsonProperty("sumCelkemMen")]
+    // public double SumCelkemMen { get; set; }
+    //
+    // [JsonProperty("sumCelkemMen@enabled")]
+    // public bool SumCelkemMenEnabled { get; set; }
+    //
+    // [JsonProperty("vypisCisDokl")]
+    // public string VypisCisDokl { get; set; }
+    //
+    // [JsonProperty("datVyst")]
+    // public string DatVyst { get; set; }
+    //
+    // [JsonProperty("poznam")]
+    // public string Poznam { get; set; }
+    //
+    // [JsonProperty("sumDphSnizMen")]
+    // public double SumDphSnizMen { get; set; }
+    //
+    // [JsonProperty("sumDphSnizMen@enabled")]
+    // public bool SumDphSnizMenEnabled { get; set; }
+    //
+    // [JsonProperty("zapocet")]
+    // public bool Zapocet { get; set; }
+    //
+    // [JsonProperty("sumCelkSniz")]
+    // public double SumCelkSniz { get; set; }
+    //
+    // [JsonProperty("sumCelkZakl")]
+    // public double SumCelkZakl { get; set; }
+    //
+    // [JsonProperty("mesto")]
+    // public string Mesto { get; set; }
+    //
+    // [JsonProperty("datUcto")]
+    // public string DatUcto { get; set; }
+    //
+    // [JsonProperty("psc")]
+    // public string Psc { get; set; }
+    //
+    // [JsonProperty("zamekK")]
+    // public string ZamekK { get; set; }
+    //
+    // [JsonProperty("zamekK@possibleValues")]
+    // public string ZamekKPossibleValues { get; set; }
+    //
+    // [JsonProperty("zamekK@showAs")]
+    // public string ZamekKShowAs { get; set; }
+    //
+    // [JsonProperty("zamekK@editable")]
+    // public bool ZamekKEditable { get; set; }
+    //
+    // [JsonProperty("stredisko@evidencePath")]
+    // public string StrediskoEvidencePath { get; set; }
+    //
+    // [JsonProperty("stredisko@internalId")]
+    // public int StrediskoInternalId { get; set; }
+    //
+    // [JsonProperty("stredisko@ref")]
+    // public string StrediskoRef { get; set; }
+    //
+    // [JsonProperty("stredisko@showAs")]
+    // public string StrediskoShowAs { get; set; }
+    //
+    // [JsonProperty("jakUhrK")]
+    // public string JakUhrK { get; set; }
+    //
+    // [JsonProperty("jakUhrK@possibleValues")]
+    // public string JakUhrKPossibleValues { get; set; }
+    //
+    // [JsonProperty("varSym")]
+    // public string VarSym { get; set; }
+    //
+    // [JsonProperty("kontaktTel")]
+    // public string KontaktTel { get; set; }
+    //
+    // [JsonProperty("banSpojDod@evidencePath")]
+    // public string BanSpojDodEvidencePath { get; set; }
+    //
+    // [JsonProperty("banSpojDod@filterValues")]
+    // public string BanSpojDodFilterValues { get; set; }
+    //
+    // [JsonProperty("banSpojDod@if-not-found")]
+    // public string BanSpojDodIfNotFound { get; set; }
+    //
+    // [JsonProperty("banSpojDod")]
+    // public List<object> BanSpojDod { get; set; }
+    //
+    // [JsonProperty("uzivatel")]
+    // public string Uzivatel { get; set; }
+    //
+    // [JsonProperty("uzivatel@evidencePath")]
+    // public string UzivatelEvidencePath { get; set; }
+    //
+    // [JsonProperty("uzivatel@internalId")]
+    // public int UzivatelInternalId { get; set; }
+    //
+    // [JsonProperty("uzivatel@ref")]
+    // public string UzivatelRef { get; set; }
+    //
+    // [JsonProperty("uzivatel@showAs")]
+    // public string UzivatelShowAs { get; set; }
+    //
+    // [JsonProperty("uzivatel@editable")]
+    // public bool UzivatelEditable { get; set; }
+    //
+    // [JsonProperty("rada")]
+    // public string Rada { get; set; }
+    //
+    // [JsonProperty("rada@evidencePath")]
+    // public string RadaEvidencePath { get; set; }
+    //
+    // [JsonProperty("rada@internalId")]
+    // public int RadaInternalId { get; set; }
+    //
+    // [JsonProperty("rada@ref")]
+    // public string RadaRef { get; set; }
+    //
+    // [JsonProperty("rada@showAs")]
+    // public string RadaShowAs { get; set; }
+    //
+    // [JsonProperty("rada@if-not-found")]
+    // public string RadaIfNotFound { get; set; }
+    //
+    // [JsonProperty("sumZklZaklMen")]
+    // public double SumZklZaklMen { get; set; }
+    //
+    // [JsonProperty("sumZklZaklMen@label")]
+    // public string SumZklZaklMenLabel { get; set; }
+    //
+    // [JsonProperty("sumZklZaklMen@enabled")]
+    // public bool SumZklZaklMenEnabled { get; set; }
+    //
+    // [JsonProperty("primUcet")]
+    // public string PrimUcet { get; set; }
+    //
+    // [JsonProperty("primUcet@evidencePath")]
+    // public string PrimUcetEvidencePath { get; set; }
+    //
+    // [JsonProperty("primUcet@internalId")]
+    // public int PrimUcetInternalId { get; set; }
+    //
+    // [JsonProperty("primUcet@ref")]
+    // public string PrimUcetRef { get; set; }
+    //
+    // [JsonProperty("primUcet@showAs")]
+    // public string PrimUcetShowAs { get; set; }
+    //
+    // [JsonProperty("cinnost")]
+    // public string Cinnost { get; set; }
+    //
+    // [JsonProperty("cinnost@evidencePath")]
+    // public string CinnostEvidencePath { get; set; }
+    //
+    // [JsonProperty("cisSouhrnne")]
+    // public string CisSouhrnne { get; set; }
+    //
+    // [JsonProperty("cisSouhrnne@editable")]
+    // public bool CisSouhrnneEditable { get; set; }
+    //
+    // [JsonProperty("zuctovano")]
+    // public bool Zuctovano { get; set; }
+    //
+    // [JsonProperty("zuctovano@editable")]
+    // public bool ZuctovanoEditable { get; set; }
+    //
+    // [JsonProperty("bic")]
+    // public string Bic { get; set; }
+    //
+    // [JsonProperty("sumDphSniz2Men")]
+    // public double SumDphSniz2Men { get; set; }
+    //
+    // [JsonProperty("sumDphSniz2Men@enabled")]
+    // public bool SumDphSniz2MenEnabled { get; set; }
+    //
+    // [JsonProperty("prilohy")]
+    // public List<object> Prilohy { get; set; }
+    //
+    // [JsonProperty("vazby")]
+    // public List<object> Vazby { get; set; }
+    //
+    // [JsonProperty("smerKod@editable")]
+    // public bool SmerKodEditable { get; set; }
 }

--- a/src/Rem.FlexiBeeSDK.Model/Payments/BankUnpairRequest.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Payments/BankUnpairRequest.cs
@@ -7,7 +7,7 @@ public class BankUnpairRequest
 {
     [JsonProperty("id")]
     public string Id { get; set; }
-        
+
     [JsonProperty("odparovani")]
     public List<object> Args { get; set; } = new();
 }

--- a/src/Rem.FlexiBeeSDK.Model/Products/BoM/BomRequest.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Products/BoM/BomRequest.cs
@@ -35,7 +35,7 @@ public class BomRequest
         Filter = $"otecCenik.kod eq \"{Code}\"";
         return this;
     }
-    
+
     public BomRequest FindByIngredientCode(string code)
     {
         Code = code;

--- a/src/Rem.FlexiBeeSDK.Model/Products/Lots/LotsItem.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Products/Lots/LotsItem.cs
@@ -14,5 +14,5 @@ public class LotsItem
     [JsonProperty("cenik")]
     public string ProductCode { get; set; }
     [JsonProperty("pocet")]
-    public decimal Amount { get; set; } 
+    public decimal Amount { get; set; }
 }

--- a/src/Rem.FlexiBeeSDK.Model/Products/PriceList/PriceListCollectionFlexiDto.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Products/PriceList/PriceListCollectionFlexiDto.cs
@@ -7,7 +7,7 @@ public class PriceListCollectionFlexiDto
     {
         PriceList = [priceListData];
     }
-        
+
     [JsonProperty("cenik", NullValueHandling = NullValueHandling.Ignore)]
     public List<PriceListFlexiDto> PriceList { get; set; }
 

--- a/src/Rem.FlexiBeeSDK.Model/Products/Sets/ProductSetFlexiDto.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Products/Sets/ProductSetFlexiDto.cs
@@ -16,7 +16,7 @@ public class ProductSetFlexiDto
     public List<ProductSetsProductFlexiDto> ProductList { get; set; }
 
     public ProductSetsProductFlexiDto Product => ProductList.FirstOrDefault()!;
-    
+
     [JsonProperty("cenikSada@showAs")]
     public string SetName { get; set; }
 

--- a/src/Rem.FlexiBeeSDK.Model/Products/Sets/ProductSetsRequest.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Products/Sets/ProductSetsRequest.cs
@@ -8,7 +8,7 @@ public class ProductSetsRequest
     {
         Filter = $"cenikSada eq \"code:{productCode}\"";
     }
-    
+
     [JsonProperty("add-row-count")] public bool AddRowCount { get; set; } = true;
 
     [JsonProperty("detail")] public string Detail { get; set; } = "custom:mnozMj,cenik(nazev,kod,id),cenikSada(nazev,kod,id),poznam,id";
@@ -26,6 +26,6 @@ public class ProductSetsRequest
     [JsonProperty("no-ext-ids")] public bool NoExtIds { get; set; } = true;
 
     [JsonProperty("@version")] public string Version { get; set; } = "1.0";
-    
+
     [JsonProperty("filter")] public string Filter { get; private set; }
 }

--- a/src/Rem.FlexiBeeSDK.Model/Products/StockMovement/StockItemDocumentFlexiDto.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Products/StockMovement/StockItemDocumentFlexiDto.cs
@@ -18,13 +18,13 @@ public class StockItemDocumentFlexiDto
 
     [JsonProperty("kod")]
     public string DocumentCode { get; set; }
-    
+
     [JsonProperty("typPohybuK")]
     public string MovementDirectionCode { get; set; }
 
     [JsonProperty("typPohybuK@showAs")]
     public string MovementDirectionName { get; set; }
-    
+
     [JsonProperty("typUcOp")]
     public string AccountTemplateRaw { get; set; }
 

--- a/src/Rem.FlexiBeeSDK.Model/Products/StockMovement/StockItemMovementFlexiDto.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Products/StockMovement/StockItemMovementFlexiDto.cs
@@ -14,7 +14,7 @@ public class StockItemMovementFlexiDto
     public List<StockItemDocumentFlexiDto> DocumentList { get; set; }
 
     public StockItemDocumentFlexiDto Document => DocumentList.First();
-    
+
     [JsonProperty("datVyst")]
     public DateTime Date { get; set; }
 

--- a/src/Rem.FlexiBeeSDK.Model/Products/StockMovement/StockItemMovementRequest.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Products/StockMovement/StockItemMovementRequest.cs
@@ -7,9 +7,9 @@ public class StockItemMovementRequest
 {
     // "(doklSklad.typDokl eq \"56\" and doklSklad.typPohybuK in (\"typPohybu.prijem\") and (doklSklad.datVyst gte \"2025-06-01\" and doklSklad.datVyst lte \"2025-06-30\"))",
     public StockItemMovementRequest(
-        DateTime dateFrom, 
-        DateTime dateTo, 
-        StockMovementDirection direction, 
+        DateTime dateFrom,
+        DateTime dateTo,
+        StockMovementDirection direction,
         string? storeCode = null,
         int? documentTypeId = null,
         string? documentCode = null
@@ -47,37 +47,37 @@ public class StockItemMovementRequest
     [JsonProperty("no-ext-ids")] public bool NoExtIds { get; set; } = true;
 
     [JsonProperty("@version")] public string Version { get; set; } = "1.0";
-    
+
     [JsonProperty("filter")] public string Filter { get; private set; }
 
-    
+
     private string GetDocumentTypeFilterString(int? documentTypeId = null)
     {
-        if(documentTypeId == null)
+        if (documentTypeId == null)
             return String.Empty;
 
         return $"and doklSklad.typDokl eq \"{documentTypeId}\"";
     }
-        
+
     private string GetDocumentNumberFilterString(string? documentNumber = null)
     {
-        if(documentNumber == null)
+        if (documentNumber == null)
             return String.Empty;
 
         return $"and doklSklad.kod eq \"{documentNumber}\"";
     }
-    
+
     private string GetStoreCodeFilterString(string? storeCode = null)
     {
-        if(storeCode == null)
+        if (storeCode == null)
             return String.Empty;
 
         return $"and sklad.kod eq \"{storeCode}\"";
     }
-        
+
     private string GetDirectionFilterString(StockMovementDirection direction)
     {
-        if(direction == StockMovementDirection.Any)
+        if (direction == StockMovementDirection.Any)
             return String.Empty;
 
         return $"and doklSklad.typPohybuK in (\"typPohybu.{(direction == StockMovementDirection.In ? "prijem" : "vydej")}\")";

--- a/src/Rem.FlexiBeeSDK.Model/Products/StockMovement/StockItemStoreFlexiDto.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Products/StockMovement/StockItemStoreFlexiDto.cs
@@ -9,7 +9,7 @@ public class StockItemStoreFlexiDto
 
     [JsonProperty("nazev")]
     public string Name { get; set; }
-    
+
     [JsonProperty("kod")]
     public string Code { get; set; }
 }

--- a/src/Rem.FlexiBeeSDK.Model/Products/StockMovement/StockItemsMovementUpsertRequestEnvelopeFlexiDto.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Products/StockMovement/StockItemsMovementUpsertRequestEnvelopeFlexiDto.cs
@@ -9,7 +9,7 @@ public class StockItemsMovementUpsertRequestEnvelopeFlexiDto
     {
         StockMovement = [stockMovementRequest];
     }
-    
+
     [JsonProperty("skladovy-pohyb", NullValueHandling = NullValueHandling.Ignore)]
     public List<StockItemsMovementUpsertRequestFlexiDto> StockMovement { get; set; }
 

--- a/src/Rem.FlexiBeeSDK.Model/Products/StockMovement/StockItemsMovementUpsertRequestFlexiDto.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Products/StockMovement/StockItemsMovementUpsertRequestFlexiDto.cs
@@ -43,7 +43,7 @@ public class StockItemsMovementUpsertRequestFlexiDto
     public string MovementTypeString => $"typPohybu.{(StockMovementDirection == StockMovementDirection.In ? "prijem" : "vydej")}";
 
     public StockMovementDirection StockMovementDirection { get; set; }
-    
+
     [JsonProperty("typPohybuSkladK", NullValueHandling = NullValueHandling.Ignore)]
     public string StockMovementTypeString => $"typPohybuSklad.{(StockMovementDirection == StockMovementDirection.In ? "prijemHoly" : "vydejHoly")}";
 

--- a/src/Rem.FlexiBeeSDK.Model/Products/StockTaking/AddStockTakingItemRequest.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Products/StockTaking/AddStockTakingItemRequest.cs
@@ -8,7 +8,7 @@ public class AddStockTakingItemRequest
     [JsonProperty("cenik")]
     public string ProductCode { get; set; }
 
-    [JsonProperty("expirace")] 
+    [JsonProperty("expirace")]
     public string Expiration { get; set; } = "";
 
     [JsonProperty("inventura")]
@@ -17,7 +17,7 @@ public class AddStockTakingItemRequest
     [JsonProperty("mnozMjReal")]
     public decimal Amount { get; set; }
 
-    [JsonProperty("sarze")] 
+    [JsonProperty("sarze")]
     public string Lot { get; set; } = "";
 
     [JsonProperty("sklad")]

--- a/src/Rem.FlexiBeeSDK.Model/Products/StockTaking/StockTakingHeader.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Products/StockTaking/StockTakingHeader.cs
@@ -7,7 +7,7 @@ public class StockTakingHeader
 {
     [JsonProperty("id")]
     public int Id { get; set; }
-    
+
     [JsonProperty("lastUpdate")]
     public DateTime LastUpdate { get; set; }
 

--- a/src/Rem.FlexiBeeSDK.Model/Products/StockTaking/StockTakingHeaderRequest.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Products/StockTaking/StockTakingHeaderRequest.cs
@@ -5,7 +5,7 @@ namespace Rem.FlexiBeeSDK.Model.Products.StockTaking;
 
 public class StockTakingHeaderRequest
 {
-    [JsonProperty("datKonec")] 
+    [JsonProperty("datKonec")]
     public DateTime DatKonec => Date;
 
     [JsonProperty("datZahaj")]

--- a/src/Rem.FlexiBeeSDK.Model/Products/StockToDate/ProductFlexiDto.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Products/StockToDate/ProductFlexiDto.cs
@@ -15,22 +15,22 @@ public class ProductFlexiDto
 
     [JsonProperty("baleniNazev1")]
     public string MoqName { get; set; }
-    
+
     [JsonProperty("baleniMj1")]
     public string MoqAmount { get; set; }
-    
+
     [JsonProperty("evidSarze")]
     public bool HasLots { get; set; }
-    
+
     [JsonProperty("evidExpir")]
     public bool HasExpiration { get; set; }
-    
+
     [JsonProperty("objem")]
     public double Volume { get; set; }
 
     [JsonProperty("hmotMj")]
     public double Weight { get; set; }
-    
+
     [JsonProperty("dodavatel")]
     public string SupplierCode { get; set; }
 
@@ -39,7 +39,7 @@ public class ProductFlexiDto
 
     [JsonProperty("dodavatel@showAs")]
     public string SupplierName { get; set; }
-    
+
     [JsonProperty("poznam")]
     public string Note { get; set; }
 }

--- a/src/Rem.FlexiBeeSDK.Model/Products/StockToDate/StockToDateItem.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Products/StockToDate/StockToDateItem.cs
@@ -21,7 +21,7 @@ public class StockToDateItem
     public int? ProductTypeId => ProductItemGroup?.FirstOrDefault()?.Id;
 
     [JsonProperty("skupZboz")]
-    public List<ProductTypeGroup> ProductItemGroup { get; set; } = new ();
+    public List<ProductTypeGroup> ProductItemGroup { get; set; } = new();
 
     [JsonProperty("stavMJ")]
     public double Amount { get; set; }

--- a/src/Rem.FlexiBeeSDK.Model/Response/ErrorType.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Response/ErrorType.cs
@@ -3,7 +3,7 @@ namespace Rem.FlexiBeeSDK.Model.Response;
 public enum ErrorType
 {
     General,
-    
+
     InvoicePaired,
     ProductNotFound
 }

--- a/src/Rem.FlexiBeeSDK.Model/Response/OperationResult.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Response/OperationResult.cs
@@ -8,7 +8,7 @@ namespace Rem.FlexiBeeSDK.Model.Response
         {
             StatusCode = statusCode;
         }
-        
+
         public OperationResult(HttpStatusCode statusCode, string error)
         {
             StatusCode = statusCode;
@@ -25,6 +25,6 @@ namespace Rem.FlexiBeeSDK.Model.Response
         public HttpStatusCode StatusCode { get; }
         public string? ErrorMessage { get; set; }
 
-        public bool IsSuccess => (int) StatusCode < 300 && (int) StatusCode >= 200;
+        public bool IsSuccess => (int)StatusCode < 300 && (int)StatusCode >= 200;
     }
 }

--- a/src/Rem.FlexiBeeSDK.Model/Response/OperationResultDetail.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Response/OperationResultDetail.cs
@@ -16,6 +16,6 @@ public class OperationResultDetail
 
     [JsonProperty("message")]
     public string Message { get; set; }
-    
+
     public bool IsSuccess => Success == "true";
 }

--- a/src/Rem.FlexiBeeSDK.Model/Response/OperationResultExtensions.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Response/OperationResultExtensions.cs
@@ -7,7 +7,7 @@ public static class OperationResultExtensions
     {
         if (result.IsSuccess)
             return null;
-        
+
         return result.ErrorMessage ?? result.Result?.Results?.FirstOrDefault()?.Errors?.FirstOrDefault()?.Message;
     }
 }

--- a/test/Rem.FlexiBeeSDK.Tests/LedgerItemFlexiDtoTests.cs
+++ b/test/Rem.FlexiBeeSDK.Tests/LedgerItemFlexiDtoTests.cs
@@ -1,0 +1,41 @@
+using System;
+using Newtonsoft.Json;
+using Rem.FlexiBeeSDK.Model.Accounting.Ledger;
+using Xunit;
+
+namespace Rem.FlexiBeeSDK.Tests;
+
+public class LedgerItemFlexiDtoTests
+{
+    [Fact]
+    public void Deserialize_WithLastUpdate_PopulatesLastUpdateProperty()
+    {
+        var json = """
+            {
+                "id": 42,
+                "lastUpdate": "2025-05-20T14:30:00.000+02:00"
+            }
+            """;
+
+        var dto = JsonConvert.DeserializeObject<LedgerItemFlexiDto>(json);
+
+        Assert.NotNull(dto);
+        Assert.NotNull(dto.LastUpdate);
+        Assert.Equal(42, dto.Id);
+        // FlexiBee returns offset-aware strings; Newtonsoft converts to local DateTime
+        // so we compare the UTC representation
+        var expectedUtc = new DateTimeOffset(2025, 5, 20, 14, 30, 0, TimeSpan.FromHours(2)).UtcDateTime;
+        Assert.Equal(expectedUtc, dto.LastUpdate!.Value.ToUniversalTime());
+    }
+
+    [Fact]
+    public void Deserialize_WithoutLastUpdate_LastUpdateIsNull()
+    {
+        var json = """{ "id": 99 }""";
+
+        var dto = JsonConvert.DeserializeObject<LedgerItemFlexiDto>(json);
+
+        Assert.NotNull(dto);
+        Assert.Null(dto.LastUpdate);
+    }
+}

--- a/test/Rem.FlexiBeeSDK.Tests/LedgerItemFlexiDtoTests.cs
+++ b/test/Rem.FlexiBeeSDK.Tests/LedgerItemFlexiDtoTests.cs
@@ -22,10 +22,8 @@ public class LedgerItemFlexiDtoTests
         Assert.NotNull(dto);
         Assert.NotNull(dto.LastUpdate);
         Assert.Equal(42, dto.Id);
-        // FlexiBee returns offset-aware strings; Newtonsoft converts to local DateTime
-        // so we compare the UTC representation
-        var expectedUtc = new DateTimeOffset(2025, 5, 20, 14, 30, 0, TimeSpan.FromHours(2)).UtcDateTime;
-        Assert.Equal(expectedUtc, dto.LastUpdate!.Value.ToUniversalTime());
+        var expected = new DateTimeOffset(2025, 5, 20, 14, 30, 0, TimeSpan.FromHours(2));
+        Assert.Equal(expected, dto.LastUpdate!.Value);
     }
 
     [Fact]

--- a/test/Rem.FlexiBeeSDK.Tests/LedgerRequestTests.cs
+++ b/test/Rem.FlexiBeeSDK.Tests/LedgerRequestTests.cs
@@ -302,11 +302,77 @@ namespace Rem.FlexiBeeSDK.Tests
         {
             var dateFrom = new DateTime(2025, 6, 1);
             var dateTo = new DateTime(2025, 6, 30);
-            var request = new LedgerRequest(dateFrom, dateTo, 
+            var request = new LedgerRequest(dateFrom, dateTo,
                 debitAccountPrefixes: new List<string> { "52", "53" });
-            
+
             var expectedFilter = "((datUcto gte \"2025-06-01\" and datUcto lte \"2025-06-30\")  and (mdUcet.kod begins \"52\" or mdUcet.kod begins \"53\")  )";
             Assert.Equal(expectedFilter, request.Filter);
+        }
+    }
+
+    public class LedgerChangedSinceRequestTests
+    {
+        [Fact]
+        public void Constructor_WithSince_FilterContainsLastUpdateGte()
+        {
+            var since = new DateTime(2025, 5, 21, 10, 30, 0, DateTimeKind.Utc);
+
+            var request = new LedgerRequest(since);
+
+            Assert.Contains("lastUpdate gte", request.Filter);
+            Assert.Contains("2025-05-21T10:30:00Z", request.Filter);
+        }
+
+        [Fact]
+        public void Constructor_WithSince_FilterDoesNotContainDatUcto()
+        {
+            var since = new DateTime(2025, 5, 21, 10, 30, 0, DateTimeKind.Utc);
+
+            var request = new LedgerRequest(since);
+
+            Assert.DoesNotContain("datUcto", request.Filter);
+        }
+
+        [Fact]
+        public void Constructor_WithSince_FilterMatchesExpectedFormat()
+        {
+            var since = new DateTime(2025, 5, 21, 10, 30, 0, DateTimeKind.Utc);
+
+            var request = new LedgerRequest(since);
+
+            Assert.Equal("(lastUpdate gte \"2025-05-21T10:30:00Z\")", request.Filter);
+        }
+
+        [Fact]
+        public void Constructor_WithSince_FilterAlwaysContainsUtcMarker()
+        {
+            var since = new DateTime(2025, 5, 21, 10, 30, 0, DateTimeKind.Utc);
+
+            var request = new LedgerRequest(since);
+
+            // Filter must always contain a UTC representation (timestamp ends with Z)
+            Assert.Contains("Z\"", request.Filter);
+        }
+
+        [Fact]
+        public void Constructor_WithSince_OrderIsLastUpdate()
+        {
+            var since = new DateTime(2025, 5, 21, 0, 0, 0, DateTimeKind.Utc);
+
+            var request = new LedgerRequest(since);
+
+            Assert.Equal("lastUpdate", request.Order);
+        }
+
+        [Fact]
+        public void Constructor_WithSince_DefaultPaginationIsZero()
+        {
+            var since = new DateTime(2025, 5, 21, 0, 0, 0, DateTimeKind.Utc);
+
+            var request = new LedgerRequest(since);
+
+            Assert.Equal(0, request.Limit);
+            Assert.Equal(0, request.Start);
         }
     }
 }

--- a/test/Rem.FlexiBeeSDK.Tests/LedgerRequestTests.cs
+++ b/test/Rem.FlexiBeeSDK.Tests/LedgerRequestTests.cs
@@ -374,5 +374,21 @@ namespace Rem.FlexiBeeSDK.Tests
             Assert.Equal(0, request.Limit);
             Assert.Equal(0, request.Start);
         }
+
+        [Fact]
+        public void Constructor_WithUnspecifiedKind_ThrowsArgumentException()
+        {
+            var since = new DateTime(2025, 5, 21, 10, 30, 0);
+
+            Assert.Throws<ArgumentException>(() => new LedgerRequest(since));
+        }
+
+        [Fact]
+        public void Constructor_WithLocalKind_ThrowsArgumentException()
+        {
+            var since = new DateTime(2025, 5, 21, 10, 30, 0, DateTimeKind.Local);
+
+            Assert.Throws<ArgumentException>(() => new LedgerRequest(since));
+        }
     }
 }

--- a/test/Rem.FlexiBeeSDK.Tests/LedgerRequestTests.cs
+++ b/test/Rem.FlexiBeeSDK.Tests/LedgerRequestTests.cs
@@ -197,7 +197,7 @@ namespace Rem.FlexiBeeSDK.Tests
             Assert.True(request.UseInternalId);
             Assert.True(request.NoExtIds);
             Assert.Equal("1.0", request.Version);
-            Assert.Equal("custom:parSymbol,datVyst,datUcto,doklad,nazFirmy,stredisko(nazev,kod,id),popis,sumTuz,sumMen,mena(kod),kurz,mdUcet(kod,nazev,id),dalUcet(kod,nazev,id),zuctovano,idUcetniDenik,idDokl", request.Detail);
+            Assert.Equal("custom:parSymbol,datVyst,datUcto,doklad,nazFirmy,stredisko(nazev,kod,id),popis,sumTuz,sumMen,mena(kod),kurz,mdUcet(kod,nazev,id),dalUcet(kod,nazev,id),zuctovano,idUcetniDenik,idDokl,lastUpdate", request.Detail);
             Assert.Equal("/ucetni-denik/stredisko,/ucetni-denik/mena,/ucetni-denik/mdUcet,/ucetni-denik/dalUcet", request.Includes);
         }
         

--- a/test/Rem.FlexiBeeSDK.Tests/LedgerTests.cs
+++ b/test/Rem.FlexiBeeSDK.Tests/LedgerTests.cs
@@ -104,13 +104,13 @@ namespace Rem.FlexiBeeSDK.Tests
         public async Task GetChangedSince_ReturnsRowsWithPopulatedLastUpdate()
         {
             var client = _fixture.Create<LedgerClient>();
-            var since = DateTime.UtcNow.AddDays(-30);
+            var since = DateTimeOffset.UtcNow.AddDays(-30);
 
-            var items = await client.GetChangedSinceAsync(since, limit: 10);
+            var items = await client.GetChangedSinceAsync(since.UtcDateTime, limit: 10);
 
             items.Should().NotBeNull();
             items.Should().OnlyContain(item => item.LastUpdate.HasValue);
-            items.Should().OnlyContain(item => item.LastUpdate!.Value.ToUniversalTime() >= since.ToUniversalTime());
+            items.Should().OnlyContain(item => item.LastUpdate!.Value >= since);
         }
 
         [Fact]

--- a/test/Rem.FlexiBeeSDK.Tests/LedgerTests.cs
+++ b/test/Rem.FlexiBeeSDK.Tests/LedgerTests.cs
@@ -92,12 +92,37 @@ namespace Rem.FlexiBeeSDK.Tests
             var dateFrom = DateTime.Parse("2025-06-01");
             var dateTo = DateTime.Parse("2025-06-30");
             var departmentId = "VYROBA";
-            
+
 
             var ledger = await client.GetAsync(dateFrom, dateTo, departmentId: departmentId);
 
             ledger.Should().NotBeEmpty();
             ledger.Should().OnlyContain(w => w.CreditAccount != null && w.Department.Code.Equals(departmentId, StringComparison.InvariantCultureIgnoreCase));
+        }
+
+        [Fact]
+        public async Task GetChangedSince_ReturnsRowsWithPopulatedLastUpdate()
+        {
+            var client = _fixture.Create<LedgerClient>();
+            var since = DateTime.UtcNow.AddDays(-30);
+
+            var items = await client.GetChangedSinceAsync(since, limit: 10);
+
+            items.Should().NotBeNull();
+            items.Should().OnlyContain(item => item.LastUpdate.HasValue);
+            items.Should().OnlyContain(item => item.LastUpdate!.Value.ToUniversalTime() >= since.ToUniversalTime());
+        }
+
+        [Fact]
+        public async Task GetChangedSince_WithFutureDate_ReturnsEmptyList()
+        {
+            var client = _fixture.Create<LedgerClient>();
+            var futureDate = DateTime.UtcNow.AddDays(1);
+
+            var items = await client.GetChangedSinceAsync(futureDate);
+
+            items.Should().NotBeNull();
+            items.Should().BeEmpty();
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds `ILedgerClient.GetChangedSinceAsync(DateTime since, ...)` that filters `ucetni-denik` rows via `lastUpdate gte "<since>"`, enabling true watermark-based CDC instead of a rolling 7-day window.
- Adds `LedgerItemFlexiDto.LastUpdate` (`DateTime?`) so callers can advance their watermark after each batch.
- Extends `LedgerRequest.Detail` to include `lastUpdate`, ensuring FlexiBee returns the field in responses; guards against non-UTC `DateTime` input with `ArgumentException`.
- Applies `dotnet format` whitespace cleanup across model files.

## Test Plan

- [ ] Run `dotnet test test/Rem.FlexiBeeSDK.Tests/ --filter "FullyQualifiedName~LedgerRequestTests|FullyQualifiedName~LedgerChangedSinceRequestTests|FullyQualifiedName~LedgerItemFlexiDtoTests"` — all 31 unit tests pass
- [ ] Run integration tests against a live FlexiBee staging instance: `GetChangedSince_ReturnsRowsWithPopulatedLastUpdate` and `GetChangedSince_WithFutureDate_ReturnsEmptyList`