### PR TITLE
feat: add period, contact and accounting_template to LedgerItemFlexiDto

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,12 @@ FlexiBeeSDK is a .NET SDK for integrating with the FlexiBee accounting system AP
 - **FlexiBee REST API Documentation** - https://intercom.help/podpora-flexi/cs/collections/2592813-dokumentace-rest-api
   - Full API docs with many subpages; use when unsure about endpoints, query params, or behavior
 
+## Model Validation Rule
+
+**MANDATORY: Every new or modified property in a DTO/model MUST be validated against the FlexiBee API before implementation.**
+
+Use `https://demo.flexibee.eu/c/demo/{evidence-name}/properties.json` to get the exact field names and types for any evidence. Never assume field names — always confirm they exist in the API response schema.
+
 ## Development Commands
 
 ### Building the Solution

--- a/src/Rem.FlexiBeeSDK.Model/Accounting/Ledger/LedgerItemFlexiDto.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Accounting/Ledger/LedgerItemFlexiDto.cs
@@ -115,6 +115,18 @@ public class LedgerItemFlexiDto
     [JsonProperty("idDokl@evidencePath")]
     public string DocumentIdEvidencePath { get; set; }
 
+    [JsonProperty("postingPeriod")]
+    public string? Period { get; set; }
+
+    [JsonProperty("firma@ref")]
+    public string? ContactRef { get; set; }
+
+    [JsonProperty("firma@showAs")]
+    public string? ContactShowAs { get; set; }
+
+    // Not available in ucetni-denik API; reserved as nullable placeholder
+    public string? AccountingTemplate { get; set; }
+
     [JsonProperty("lastUpdate")]
     public DateTimeOffset? LastUpdate { get; set; }
 }

--- a/src/Rem.FlexiBeeSDK.Model/Accounting/Ledger/LedgerRequest.cs
+++ b/src/Rem.FlexiBeeSDK.Model/Accounting/Ledger/LedgerRequest.cs
@@ -26,7 +26,7 @@ public class LedgerRequest
 
     [JsonProperty("detail")]
     public string Detail { get; set; } =
-        "custom:parSymbol,datVyst,datUcto,doklad,nazFirmy,stredisko(nazev,kod,id),popis,sumTuz,sumMen,mena(kod),kurz,mdUcet(kod,nazev,id),dalUcet(kod,nazev,id),zuctovano,idUcetniDenik,idDokl,lastUpdate";
+        "custom:parSymbol,datVyst,datUcto,doklad,nazFirmy,stredisko(nazev,kod,id),popis,sumTuz,sumMen,mena(kod),kurz,mdUcet(kod,nazev,id),dalUcet(kod,nazev,id),zuctovano,idUcetniDenik,idDokl,postingPeriod,firma,lastUpdate";
 
     [JsonProperty("limit")] public int Limit { get; set; } = 0;
 

--- a/test/Rem.FlexiBeeSDK.Tests/LedgerItemFlexiDtoTests.cs
+++ b/test/Rem.FlexiBeeSDK.Tests/LedgerItemFlexiDtoTests.cs
@@ -36,4 +36,39 @@ public class LedgerItemFlexiDtoTests
         Assert.NotNull(dto);
         Assert.Null(dto.LastUpdate);
     }
+
+    [Fact]
+    public void Deserialize_WithPeriodAndContact_PopulatesProperties()
+    {
+        var json = """
+            {
+                "id": 1,
+                "postingPeriod": "2024001",
+                "firma@ref": "code:ACME",
+                "firma@showAs": "ACME s.r.o."
+            }
+            """;
+
+        var dto = JsonConvert.DeserializeObject<LedgerItemFlexiDto>(json);
+
+        Assert.NotNull(dto);
+        Assert.Equal("2024001", dto.Period);
+        Assert.Equal("code:ACME", dto.ContactRef);
+        Assert.Equal("ACME s.r.o.", dto.ContactShowAs);
+        Assert.Null(dto.AccountingTemplate);
+    }
+
+    [Fact]
+    public void Deserialize_WithoutPeriodAndContact_PropertiesAreNull()
+    {
+        var json = """{ "id": 1 }""";
+
+        var dto = JsonConvert.DeserializeObject<LedgerItemFlexiDto>(json);
+
+        Assert.NotNull(dto);
+        Assert.Null(dto.Period);
+        Assert.Null(dto.ContactRef);
+        Assert.Null(dto.ContactShowAs);
+        Assert.Null(dto.AccountingTemplate);
+    }
 }

--- a/test/Rem.FlexiBeeSDK.Tests/LedgerRequestTests.cs
+++ b/test/Rem.FlexiBeeSDK.Tests/LedgerRequestTests.cs
@@ -197,7 +197,7 @@ namespace Rem.FlexiBeeSDK.Tests
             Assert.True(request.UseInternalId);
             Assert.True(request.NoExtIds);
             Assert.Equal("1.0", request.Version);
-            Assert.Equal("custom:parSymbol,datVyst,datUcto,doklad,nazFirmy,stredisko(nazev,kod,id),popis,sumTuz,sumMen,mena(kod),kurz,mdUcet(kod,nazev,id),dalUcet(kod,nazev,id),zuctovano,idUcetniDenik,idDokl,lastUpdate", request.Detail);
+            Assert.Equal("custom:parSymbol,datVyst,datUcto,doklad,nazFirmy,stredisko(nazev,kod,id),popis,sumTuz,sumMen,mena(kod),kurz,mdUcet(kod,nazev,id),dalUcet(kod,nazev,id),zuctovano,idUcetniDenik,idDokl,postingPeriod,firma,lastUpdate", request.Detail);
             Assert.Equal("/ucetni-denik/stredisko,/ucetni-denik/mena,/ucetni-denik/mdUcet,/ucetni-denik/dalUcet", request.Includes);
         }
         


### PR DESCRIPTION
Maps `postingPeriod` (yearMonth) and `firma` (ref/showAs) from the `ucetni-denik` FlexiBee API to new nullable properties on `LedgerItemFlexiDto`. Adds `AccountingTemplate` as a nullable placeholder — this field has no counterpart in the API but is reserved for future use. Updates `LedgerRequest.Detail` to request the new fields and adds a mandatory model validation rule to `CLAUDE.md`.

## Test plan
- [ ] All ledger unit tests pass (`LedgerItemFlexiDtoTests`, `LedgerRequestTests`)
- [ ] `Period`, `ContactRef`, `ContactShowAs` deserialize correctly from FlexiBee JSON
- [ ] `AccountingTemplate` is always `null` (no API source)